### PR TITLE
Update swedbank-pay-design-guide-theme.scss

### DIFF
--- a/assets/css/swedbank-pay-design-guide-theme.scss
+++ b/assets/css/swedbank-pay-design-guide-theme.scss
@@ -122,6 +122,7 @@ a[href ^= 'https://']:not([href *= '{{ site.url }}']):after {
 
     svg {
         width: 100% !important;
+        height: 100%;
     }
 
     rect.actor {


### PR DESCRIPTION
This fixes the absurd amount of margin above and below of mermaid schemas.