### PR TITLE
Change from hardcoded to computed buffer

### DIFF
--- a/assets/js/swedbank-pay-design-guide-theme.js
+++ b/assets/js/swedbank-pay-design-guide-theme.js
@@ -33,8 +33,7 @@
     };
 
     window.addEventListener("scroll", function() {
-        // TODO: Figure out a way to compute the buffer instead of hard coding it.
-        var buffer = 150;
+        var buffer = (document.documentElement.scrollHeight - getPosition(headings[headings.length - 1])) / 2;
         var currentPos = window.pageYOffset + buffer;
 
         // TODO: Probably a stupid way to compute "how far left can we scroll until


### PR DESCRIPTION
Added a simple solution to compute the buffer. The proposed solution makes the last sidebar(doctoc) link active when a bit more than half of the last subsection is showing. This is due to the footer height not being taken into account in the computation. If "exactly" half is more desirable, computing with the footer height can be implemented. 