### PR TITLE
Change to computed buffer for sidebar

### DIFF
--- a/assets/js/swedbank-pay-design-guide-theme.js
+++ b/assets/js/swedbank-pay-design-guide-theme.js
@@ -33,8 +33,7 @@
     };
 
     window.addEventListener("scroll", function() {
-        // TODO: Figure out a way to compute the buffer instead of hard coding it.
-        var buffer = 150;
+        var buffer = document.body.clientHeight * 0.1;
         var currentPos = window.pageYOffset + buffer;
 
         // TODO: Probably a stupid way to compute "how far left can we scroll until


### PR DESCRIPTION
Just suggesting a simple solution to remove the hard coded buffer value. Using 10% of the clientHeight means that the buffer gets smaller as the window height decreases, which initially makes sense to me