### PR TITLE
Fix "float: left" material icons in table

### DIFF
--- a/assets/css/swedbank-pay-design-guide-theme.scss
+++ b/assets/css/swedbank-pay-design-guide-theme.scss
@@ -14,6 +14,15 @@ img {
     max-width: 100%;
 }
 
+.table {
+    th,
+    td {
+        > .material-icons {
+            float: none;
+        }
+    }
+}
+
 p.code-header {
     display: block;
     padding: 5px 19px;


### PR DESCRIPTION
Design guide adds "float: left" to material icons in tables, making it difficult to align items (i.e center align items as done in [payment-instrument-availability](https://www.figma.com/file/Q0KgLsOaiRT0eNaYeUf3Nw/Developer-Portal---Old%2FExtra?node-id=33%3A0)).