### PR TITLE
Various post-upgrade adjustments

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,8 +5,7 @@ on:
     branches: [ master ]
 
 jobs:
-  build:
-    name: Deploy
+  deploy:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,6 @@ on: [push, pull_request]
 
 jobs:
   build:
-    name: Build
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -18,7 +17,6 @@ jobs:
           --exit-code-from jekyll
 
   test:
-    name: Test
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/.remarkrc.yaml
+++ b/.remarkrc.yaml
@@ -1,6 +1,5 @@
 plugins:
   - "remark-frontmatter"
-  - "remark-inline-links"
   - "remark-lint"
   - "remark-lint-no-empty-sections"
   - "remark-lint-code"

--- a/_includes/apple-mobile-headers.html
+++ b/_includes/apple-mobile-headers.html
@@ -1,6 +1,6 @@
-{% assign design_guide_version_url = include.design_guide_version_url %}
+{% assign design_guide_url = include.design_guide_url %}
 <meta name="apple-mobile-web-app-capable" content="yes">
 <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
 <meta name="apple-mobile-web-app-title" content="{{ page.title }}">
-{% include apple-touch-icons.md design_guide_version_url=design_guide_version_url -%}
-{% include apple-touch-startup-images.md design_guide_version_url=design_guide_version_url -%}
+{% include apple-touch-icons.md design_guide_url=design_guide_url -%}
+{% include apple-touch-startup-images.md design_guide_url=design_guide_url -%}

--- a/_includes/apple-mobile-headers.html
+++ b/_includes/apple-mobile-headers.html
@@ -1,0 +1,6 @@
+{% assign design_guide_version_url = include.design_guide_version_url %}
+<meta name="apple-mobile-web-app-capable" content="yes">
+<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+<meta name="apple-mobile-web-app-title" content="{{ page.title }}">
+{% include apple-touch-icons.md design_guide_version_url=design_guide_version_url -%}
+{% include apple-touch-startup-images.md design_guide_version_url=design_guide_version_url -%}

--- a/_includes/apple-touch-icon.html
+++ b/_includes/apple-touch-icon.html
@@ -1,0 +1,4 @@
+{%- assign stripped_size = include.size | strip -%}
+{%- assign size_string = stripped_size | append: 'x' | append: stripped_size -%}
+{%- assign design_guide_version_url = include.design_guide_version_url -%}
+<link rel="apple-touch-icon" sizes="{{ size_string }}" href="{{ design_guide_version_url }}/icons/apple-touch-icon-{{ size_string }}.png">

--- a/_includes/apple-touch-icon.html
+++ b/_includes/apple-touch-icon.html
@@ -1,4 +1,4 @@
 {%- assign stripped_size = include.size | strip -%}
 {%- assign size_string = stripped_size | append: 'x' | append: stripped_size -%}
-{%- assign design_guide_version_url = include.design_guide_version_url -%}
-<link rel="apple-touch-icon" sizes="{{ size_string }}" href="{{ design_guide_version_url }}/icons/apple-touch-icon-{{ size_string }}.png">
+{%- assign design_guide_url = include.design_guide_url -%}
+<link rel="apple-touch-icon" sizes="{{ size_string }}" href="{{ design_guide_url }}/icons/apple-touch-icon-{{ size_string }}.png">

--- a/_includes/apple-touch-icons.md
+++ b/_includes/apple-touch-icons.md
@@ -1,0 +1,9 @@
+{% comment -%}
+TODO: Figure out how to use front matter with proper arrays instead of split
+strings.
+{%- endcomment -%}
+{% assign design_guide_version_url = include.design_guide_version_url %}
+{%- assign sizes = "57, 60, 72, 76, 114, 120, 144, 152, 167, 180, 1024" | split: ',' -%}
+{%- for size in sizes -%}
+    {%- include apple-touch-icon.html size=size design_guide_version_url=design_guide_version_url -%}
+{%- endfor -%}

--- a/_includes/apple-touch-icons.md
+++ b/_includes/apple-touch-icons.md
@@ -2,8 +2,8 @@
 TODO: Figure out how to use front matter with proper arrays instead of split
 strings.
 {%- endcomment -%}
-{% assign design_guide_version_url = include.design_guide_version_url %}
+{% assign design_guide_url = include.design_guide_url %}
 {%- assign sizes = "57, 60, 72, 76, 114, 120, 144, 152, 167, 180, 1024" | split: ',' -%}
 {%- for size in sizes -%}
-    {%- include apple-touch-icon.html size=size design_guide_version_url=design_guide_version_url -%}
+    {%- include apple-touch-icon.html size=size design_guide_url=design_guide_url -%}
 {%- endfor -%}

--- a/_includes/apple-touch-startup-image.html
+++ b/_includes/apple-touch-startup-image.html
@@ -3,7 +3,7 @@
 {%- assign image_size = include.size | strip -%}
 {%- assign device_orientation = include.orientation | default: nil | strip -%}
 {%- assign device_pixel_ratio = include.pixel_ratio | strip -%}
-{%- assign design_guide_version_url = include.design_guide_version_url -%}
+{%- assign design_guide_url = include.design_guide_url -%}
 {%- capture device_width_string -%}
 (device-width: {{ device_width }})
 {%- endcapture -%}
@@ -20,4 +20,4 @@
 {%- endcapture -%}
 <link rel="apple-touch-startup-image"
     media="{{ device_width_string }} and {{ device_height_string }} and {{ device_orientation_string }} {{ pixel_ratio_string }}"
-    href="{{ design_guide_version_url }}/icons/apple-touch-startup-image-{{- image_size -}}.png">
+    href="{{ design_guide_url }}/icons/apple-touch-startup-image-{{- image_size -}}.png">

--- a/_includes/apple-touch-startup-image.html
+++ b/_includes/apple-touch-startup-image.html
@@ -1,0 +1,23 @@
+{%- assign device_width = include.width | strip | append: 'px' -%}
+{%- assign device_height = include.height | strip | append: 'px' -%}
+{%- assign image_size = include.size | strip -%}
+{%- assign device_orientation = include.orientation | default: nil | strip -%}
+{%- assign device_pixel_ratio = include.pixel_ratio | strip -%}
+{%- assign design_guide_version_url = include.design_guide_version_url -%}
+{%- capture device_width_string -%}
+(device-width: {{ device_width }})
+{%- endcapture -%}
+{%- capture device_height_string -%}
+(device-height: {{ device_height }})
+{%- endcapture -%}
+{%- if device_orientation != nil && device_orientation != empty -%}
+    {%- capture device_orientation_string -%}
+    (orientation: {{ device_orientation }}) and
+    {%- endcapture -%}
+{%- endif -%}
+{%- capture pixel_ratio_string -%}
+(-webkit-device-pixel-ratio: {{ device_pixel_ratio }})
+{%- endcapture -%}
+<link rel="apple-touch-startup-image"
+    media="{{ device_width_string }} and {{ device_height_string }} and {{ device_orientation_string }} {{ pixel_ratio_string }}"
+    href="{{ design_guide_version_url }}/icons/apple-touch-startup-image-{{- image_size -}}.png">

--- a/_includes/apple-touch-startup-images.md
+++ b/_includes/apple-touch-startup-images.md
@@ -1,4 +1,4 @@
-{%- assign design_guide_version_url = include.design_guide_version_url -%}
+{%- assign design_guide_url = include.design_guide_url -%}
 {%- capture startup_image_configs -%}
 320,480,1,320x460
 320,480,2,640x920
@@ -27,5 +27,5 @@
         pixel_ratio=pixel_ratio
         size=size
         orientation=orientation
-        design_guide_version_url=design_guide_version_url -%}
+        design_guide_url=design_guide_url -%}
 {%- endfor -%}

--- a/_includes/apple-touch-startup-images.md
+++ b/_includes/apple-touch-startup-images.md
@@ -1,0 +1,31 @@
+{%- assign design_guide_version_url = include.design_guide_version_url -%}
+{%- capture startup_image_configs -%}
+320,480,1,320x460
+320,480,2,640x920
+320,568,2,640x1096
+375,667,2,750x1294
+414,736,3,1182x2208,landscape
+414,736,3,1242x2148,portrait
+768,1024,1,748x1024,landscape
+768,1024,1,768x1004,portrait
+768,1024,2,1496x2048,landscape
+768,1024,2,1536x2008,portrait
+{%- endcapture -%}
+{%- assign startup_image_configs = startup_image_configs | newline_to_br | split: '<br />' -%}
+{%- for startup_image_config in startup_image_configs -%}
+    {%- assign values = startup_image_config | split: ',' -%}
+    {%- assign width = values[0] -%}
+    {%- assign height = values[1] -%}
+    {%- assign pixel_ratio = values[2] -%}
+    {%- assign size = values[3] -%}
+    {%- if values.size > 3 -%}
+        {% assign orientation = values[4] -%}
+    {%- endif -%}
+    {%- include apple-touch-startup-image.html
+        width=width
+        height=height
+        pixel_ratio=pixel_ratio
+        size=size
+        orientation=orientation
+        design_guide_version_url=design_guide_version_url -%}
+{%- endfor -%}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -43,38 +43,9 @@
         <link rel="shortcut icon" href="{{ design_guide_version_url }}/icons/favicon.ico">
         <link rel="icon" type="image/png" sizes="16x16" href="{{ design_guide_version_url }}/icons/favicon-16x16.png">
         <link rel="icon" type="image/png" sizes="32x32" href="{{ design_guide_version_url }}/icons/favicon-32x32.png">
-        {% include apple-touch-icons.md design_guide_version_url=design_guide_version_url -%}
-        <link rel="apple-touch-startup-image"
-            media="(device-width: 320px) and (device-height: 480px) and (-webkit-device-pixel-ratio: 1)"
-            href="{{ design_guide_version_url }}/icons/apple-touch-startup-image-320x460.png">
-        <link rel="apple-touch-startup-image"
-            media="(device-width: 320px) and (device-height: 480px) and (-webkit-device-pixel-ratio: 2)"
-            href="{{ design_guide_version_url }}/icons/apple-touch-startup-image-640x920.png">
-        <link rel="apple-touch-startup-image"
-            media="(device-width: 320px) and (device-height: 568px) and (-webkit-device-pixel-ratio: 2)"
-            href="{{ design_guide_version_url }}/icons/apple-touch-startup-image-640x1096.png">
-        <link rel="apple-touch-startup-image"
-            media="(device-width: 375px) and (device-height: 667px) and (-webkit-device-pixel-ratio: 2)"
-            href="{{ design_guide_version_url }}/icons/apple-touch-startup-image-750x1294.png">
-        <link rel="apple-touch-startup-image"
-            media="(device-width: 414px) and (device-height: 736px) and (orientation: landscape) and (-webkit-device-pixel-ratio: 3)"
-            href="{{ design_guide_version_url }}/icons/apple-touch-startup-image-1182x2208.png">
-        <link rel="apple-touch-startup-image"
-            media="(device-width: 414px) and (device-height: 736px) and (orientation: portrait) and (-webkit-device-pixel-ratio: 3)"
-            href="{{ design_guide_version_url }}/icons/apple-touch-startup-image-1242x2148.png">
-        <link rel="apple-touch-startup-image"
-            media="(device-width: 768px) and (device-height: 1024px) and (orientation: landscape) and (-webkit-device-pixel-ratio: 1)"
-            href="{{ design_guide_version_url }}/icons/apple-touch-startup-image-748x1024.png">
-        <link rel="apple-touch-startup-image"
-            media="(device-width: 768px) and (device-height: 1024px) and (orientation: portrait) and (-webkit-device-pixel-ratio: 1)"
-            href="{{ design_guide_version_url }}/icons/apple-touch-startup-image-768x1004.png">
-        <link rel="apple-touch-startup-image"
-            media="(device-width: 768px) and (device-height: 1024px) and (orientation: landscape) and (-webkit-device-pixel-ratio: 2)"
-            href="{{ design_guide_version_url }}/icons/apple-touch-startup-image-1496x2048.png">
-        <link rel="apple-touch-startup-image"
-            media="(device-width: 768px) and (device-height: 1024px) and (orientation: portrait) and (-webkit-device-pixel-ratio: 2)"
-            href="{{ design_guide_version_url }}/icons/apple-touch-startup-image-1536x2008.png">
         <link rel="icon" type="image/png" sizes="228x228" href="{{ design_guide_version_url }}/icons/coast-228x228.png">
+        {% include apple-touch-icons.md design_guide_version_url=design_guide_version_url -%}
+        {% include apple-touch-startup-images.md design_guide_version_url=design_guide_version_url -%}
         <script src="{{ '/assets/js/mermaid.min.js' | relative_url }}"></script>
         {%- if site.search.enabled == true %}
         <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -21,9 +21,6 @@
         <meta name="mobile-web-app-capable" content="yes">
         <meta name="theme-color" content="#000">
         <meta name="application-name" content="{{ page.title }}">
-        <meta name="apple-mobile-web-app-capable" content="yes">
-        <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-        <meta name="apple-mobile-web-app-title" content="{{ page.title }}">
         <meta name="msapplication-TileColor" content="#000">
         <meta name="msapplication-TileImage" content="{{ design_guide_version_url }}/icons/mstile-144x144.png">
         <meta property="og:type" value="website" />
@@ -44,8 +41,7 @@
         <link rel="icon" type="image/png" sizes="16x16" href="{{ design_guide_version_url }}/icons/favicon-16x16.png">
         <link rel="icon" type="image/png" sizes="32x32" href="{{ design_guide_version_url }}/icons/favicon-32x32.png">
         <link rel="icon" type="image/png" sizes="228x228" href="{{ design_guide_version_url }}/icons/coast-228x228.png">
-        {% include apple-touch-icons.md design_guide_version_url=design_guide_version_url -%}
-        {% include apple-touch-startup-images.md design_guide_version_url=design_guide_version_url -%}
+        {%- include apple-mobile-headers.html design_guide_version_url=design_guide_version_url -%}
         <script src="{{ '/assets/js/mermaid.min.js' | relative_url }}"></script>
         {%- if site.search.enabled == true %}
         <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -178,12 +178,8 @@
 
         <script src="{{ design_guide_version_url }}/scripts/dg.js"></script>
         <script src="{{ '/assets/js/swedbank-pay-design-guide-theme.js' | relative_url }}"></script>
-        {% if site.google_analytics.tracking_id %}
-        {% include google_analytics.html %}
-        {% endif %}
+        {%- if site.google_analytics.tracking_id %}
+            {% include google_analytics.html %}
+        {%- endif %}
     </body>
-    {% if jekyll.environment == "development" %}
-    <script>document.write('<script src="http://' + (location.host || 'localhost').split(':')[0] + ':35729/livereload.js?snipver=1"></' + 'script>')</script>
-    {% endif %}
-
 </html>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -3,7 +3,7 @@
 {%- assign image = page.opengraph.image | default: site.opengraph.image -%}
 {%- assign github_branch = site.github.branch | default : "develop" -%}
 {%- assign design_guide_base_url = site.design_guide.base_url | default: 'https://design.swedbankpay.com' -%}
-{%- assign design_guide_version = site.design_guide.version | default: '4.1.0' -%}
+{%- assign design_guide_version = site.design_guide.version | default: '4.7.0' -%}
 {%- assign design_guide_version_url = design_guide_base_url | append: '/v/' | append: design_guide_version -%}
 {%- if page.sidebar.navigation == nil -%}
     {%- unless page.name contains "index"  -%}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -43,28 +43,7 @@
         <link rel="shortcut icon" href="{{ design_guide_version_url }}/icons/favicon.ico">
         <link rel="icon" type="image/png" sizes="16x16" href="{{ design_guide_version_url }}/icons/favicon-16x16.png">
         <link rel="icon" type="image/png" sizes="32x32" href="{{ design_guide_version_url }}/icons/favicon-32x32.png">
-        <link rel="apple-touch-icon" sizes="57x57"
-            href="{{ design_guide_version_url }}/icons/apple-touch-icon-57x57.png">
-        <link rel="apple-touch-icon" sizes="60x60"
-            href="{{ design_guide_version_url }}/icons/apple-touch-icon-60x60.png">
-        <link rel="apple-touch-icon" sizes="72x72"
-            href="{{ design_guide_version_url }}/icons/apple-touch-icon-72x72.png">
-        <link rel="apple-touch-icon" sizes="76x76"
-            href="{{ design_guide_version_url }}/icons/apple-touch-icon-76x76.png">
-        <link rel="apple-touch-icon" sizes="114x114"
-            href="{{ design_guide_version_url }}/icons/apple-touch-icon-114x114.png">
-        <link rel="apple-touch-icon" sizes="120x120"
-            href="{{ design_guide_version_url }}/icons/apple-touch-icon-120x120.png">
-        <link rel="apple-touch-icon" sizes="144x144"
-            href="{{ design_guide_version_url }}/icons/apple-touch-icon-144x144.png">
-        <link rel="apple-touch-icon" sizes="152x152"
-            href="{{ design_guide_version_url }}/icons/apple-touch-icon-152x152.png">
-        <link rel="apple-touch-icon" sizes="167x167"
-            href="{{ design_guide_version_url }}/icons/apple-touch-icon-167x167.png">
-        <link rel="apple-touch-icon" sizes="180x180"
-            href="{{ design_guide_version_url }}/icons/apple-touch-icon-180x180.png">
-        <link rel="apple-touch-icon" sizes="1024x1024"
-            href="{{ design_guide_version_url }}/icons/apple-touch-icon-1024x1024.png">
+        {% include apple-touch-icons.md design_guide_version_url=design_guide_version_url -%}
         <link rel="apple-touch-startup-image"
             media="(device-width: 320px) and (device-height: 480px) and (-webkit-device-pixel-ratio: 1)"
             href="{{ design_guide_version_url }}/icons/apple-touch-startup-image-320x460.png">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,50 +1,40 @@
-{%
-
-    assign title = page.title | default: "PayEx Design Guide theme for Jekyll" %}{%
-    assign description = page.opengraph.description | default: site.opengraph.description %}{%
-    assign image = page.opengraph.image | default: site.opengraph.image %}{%
-    assign github_branch = site.github.branch | default : "develop" %}{%
-    assign design_guide_base_url = site.design_guide.base_url | default: 'https://design.swedbankpay.com' %}{%
-    assign design_guide_version = site.design_guide.version | default: '4.1.0' %}{%
-    assign design_guide_version_url = design_guide_base_url | append: '/v/' | append: design_guide_version
-
-%}
-
-{% if page.sidebar.navigation == nil %}
-{% unless page.name contains "index"  %}
-
-{% assign dirname = page.dir | split: "/" | last | remove: "/" | capitalize %}
-
-{% unless dirname == "" %}
-{% assign title = dirname | append: " – " | append: title %}
-{% endunless %}
-
-{% endunless %}
-{% endif %}
+{%- assign title = page.title | default: "PayEx Design Guide theme for Jekyll" -%}
+{%- assign description = page.opengraph.description | default: site.opengraph.description -%}
+{%- assign image = page.opengraph.image | default: site.opengraph.image -%}
+{%- assign github_branch = site.github.branch | default : "develop" -%}
+{%- assign design_guide_base_url = site.design_guide.base_url | default: 'https://design.swedbankpay.com' -%}
+{%- assign design_guide_version = site.design_guide.version | default: '4.1.0' -%}
+{%- assign design_guide_version_url = design_guide_base_url | append: '/v/' | append: design_guide_version -%}
+{%- if page.sidebar.navigation == nil -%}
+    {%- unless page.name contains "index"  -%}
+        {%- assign dirname = page.dir | split: "/" | last | remove: "/" | capitalize -%}
+        {%- unless dirname == "" -%}
+            {%- assign title = dirname | append: " – " | append: title -%}
+        {%- endunless -%}
+    {%- endunless -%}
+{%- endif -%}
 <!DOCTYPE html>
 <html lang="{{ site.lang | default: "en-US" }}">
-
     <head>
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta name="mobile-web-app-capable" content="yes">
         <meta name="theme-color" content="#000">
-        <meta name="application-name" content="{{ page.title | default: 'PayEx Design Guide theme for Jekyll' }}">
+        <meta name="application-name" content="{{ page.title }}">
         <meta name="apple-mobile-web-app-capable" content="yes">
         <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-        <meta name="apple-mobile-web-app-title"
-            content="{{ page.title | default: 'PayEx Design Guide theme for Jekyll' }}">
+        <meta name="apple-mobile-web-app-title" content="{{ page.title }}">
         <meta name="msapplication-TileColor" content="#000">
         <meta name="msapplication-TileImage" content="{{ design_guide_version_url }}/icons/mstile-144x144.png">
         <meta property="og:type" value="website" />
-        {% if page.url != nil %}
+        {%- if page.url != nil %}
         <meta property="og:url" value="{{ page.url | absolute_url }}" />{% endif %}
         <meta property="og:title" value="{{ title }}" />
         <meta name="title" content="{{ title }}" />
-        {% if description != nil %}
+        {%- if description != nil %}
         <meta property="og:description" value="{{ description }}" />
         <meta name="description" content="{{ description }}" />{% endif %}
-        {% if image != nil %}
+        {%- if image != nil %}
         <meta property="og:image" value="{{ image }}" />{% endif %}
         <title>{{ title }}</title>
         <link rel="stylesheet" href="{{ design_guide_version_url }}/styles/dg-style.css" />
@@ -107,12 +97,12 @@
             href="{{ design_guide_version_url }}/icons/apple-touch-startup-image-1536x2008.png">
         <link rel="icon" type="image/png" sizes="228x228" href="{{ design_guide_version_url }}/icons/coast-228x228.png">
         <script src="{{ '/assets/js/mermaid.min.js' | relative_url }}"></script>
-        {% if site.search.enabled == true %}
+        {%- if site.search.enabled == true %}
         <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
         <script src="{{ "/assets/tipuesearch/tipuesearch_content.js" | relative_url }}"></script>
         <script src="{{ "/assets/tipuesearch/tipuesearch_set.js" | relative_url }}"></script>
         <script src="{{ "/assets/tipuesearch/tipuesearch.min.js" | relative_url }}"></script>
-        {% endif %}
+        {%- endif %}
         <link href="https://fonts.googleapis.com/css?family=Material+Icons+Outlined" rel="stylesheet">
     </head>
 
@@ -151,8 +141,8 @@
 
                         <div class="topbar-info topbar-link-right">
                             <div class="topbar-info-contact">
-                                <a href="{{ site.github.repository_url }}/tree/{{github_branch}}/{{ page.path }}"
-                                    target="_blank" rel="noopener noreferrer" title="Edit this page on GitHub">
+                                <a href="{{ site.github.repository_url }}/tree/{{ github_branch }}/{{ page.path }}" target="_blank"
+                                    rel="noopener noreferrer" title="Edit this page on GitHub">
                                     <svg aria-labelledby="simpleicons-github-icon" role="img" viewBox="0 0 24 24"
                                         xmlns="http://www.w3.org/2000/svg">
                                         <title id="simpleicons-github-icon">Edit this page on GitHub</title>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -4,7 +4,7 @@
 {%- assign github_branch = site.github.branch | default : "develop" -%}
 {%- assign design_guide_base_url = site.design_guide.base_url | default: 'https://design.swedbankpay.com' -%}
 {%- assign design_guide_version = site.design_guide.version | default: '4.7.0' -%}
-{%- assign design_guide_version_url = design_guide_base_url | append: '/v/' | append: design_guide_version -%}
+{%- assign design_guide_url = design_guide_base_url | append: '/v/' | append: design_guide_version -%}
 {%- if page.sidebar.navigation == nil -%}
     {%- unless page.name contains "index"  -%}
         {%- assign dirname = page.dir | split: "/" | last | remove: "/" | capitalize -%}
@@ -22,7 +22,7 @@
         <meta name="theme-color" content="#000">
         <meta name="application-name" content="{{ page.title }}">
         <meta name="msapplication-TileColor" content="#000">
-        <meta name="msapplication-TileImage" content="{{ design_guide_version_url }}/icons/mstile-144x144.png">
+        <meta name="msapplication-TileImage" content="{{ design_guide_url }}/icons/mstile-144x144.png">
         <meta property="og:type" value="website" />
         {%- if page.url != nil %}
         <meta property="og:url" value="{{ page.url | absolute_url }}" />{% endif %}
@@ -34,14 +34,14 @@
         {%- if image != nil %}
         <meta property="og:image" value="{{ image }}" />{% endif %}
         <title>{{ title }}</title>
-        <link rel="stylesheet" href="{{ design_guide_version_url }}/styles/dg-style.css" />
+        <link rel="stylesheet" href="{{ design_guide_url }}/styles/dg-style.css" />
         <link rel="stylesheet" href="{{ '/assets/css/swedbank-pay-design-guide-theme.css' | relative_url }}" />
         <link rel="stylesheet" href="{{ '/assets/css/pygments-autumn.css' | relative_url }}" />
-        <link rel="shortcut icon" href="{{ design_guide_version_url }}/icons/favicon.ico">
-        <link rel="icon" type="image/png" sizes="16x16" href="{{ design_guide_version_url }}/icons/favicon-16x16.png">
-        <link rel="icon" type="image/png" sizes="32x32" href="{{ design_guide_version_url }}/icons/favicon-32x32.png">
-        <link rel="icon" type="image/png" sizes="228x228" href="{{ design_guide_version_url }}/icons/coast-228x228.png">
-        {%- include apple-mobile-headers.html design_guide_version_url=design_guide_version_url -%}
+        <link rel="shortcut icon" href="{{ design_guide_url }}/icons/favicon.ico">
+        <link rel="icon" type="image/png" sizes="16x16" href="{{ design_guide_url }}/icons/favicon-16x16.png">
+        <link rel="icon" type="image/png" sizes="32x32" href="{{ design_guide_url }}/icons/favicon-32x32.png">
+        <link rel="icon" type="image/png" sizes="228x228" href="{{ design_guide_url }}/icons/coast-228x228.png">
+        {%- include apple-mobile-headers.html design_guide_url=design_guide_url -%}
         <script src="{{ '/assets/js/mermaid.min.js' | relative_url }}"></script>
         {%- if site.search.enabled == true %}
         <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
@@ -57,7 +57,7 @@
             <header class="topbar topbar-md-wide designguide-header">
                 <button type="button" class="topbar-btn"><i class="material-icons topbar-btn-icon">menu</i></button>
                 <a href="{{ site.url }}" class="topbar-logo"><img
-                        src="{{ design_guide_version_url }}/img/swedbankpay-logo.svg" alt="logo"></a>
+                        src="{{ design_guide_url }}/img/swedbankpay-logo.svg" alt="logo"></a>
                 <nav class="topbar-nav">
                     <div class="topbar-link-container">
                         <button type="button" class="topbar-close"><i class="material-icons">close</i></button>
@@ -172,7 +172,7 @@
             </footer>
         </div>
 
-        <script src="{{ design_guide_version_url }}/scripts/dg.js"></script>
+        <script src="{{ design_guide_url }}/scripts/dg.js"></script>
         <script src="{{ '/assets/js/swedbank-pay-design-guide-theme.js' | relative_url }}"></script>
         {%- if site.google_analytics.tracking_id %}
             {% include google_analytics.html %}

--- a/assets/css/swedbank-pay-design-guide-theme.scss
+++ b/assets/css/swedbank-pay-design-guide-theme.scss
@@ -87,7 +87,7 @@ a.header-anchor::before {
 a[href ^= '//']:not([href *= '{{ site.url }}']):after,
 a[href ^= 'http://']:not([href *= '{{ site.url }}']):after,
 a[href ^= 'https://']:not([href *= '{{ site.url }}']):after {
-        content: url('../img/external-url.svg');;
+    content: url('../img/external-url.svg');
     margin-left: .3rem;
     display: inline-block;
     width: .8rem;
@@ -95,9 +95,29 @@ a[href ^= 'https://']:not([href *= '{{ site.url }}']):after {
     color: #257886;
 }
 
+#designguide .designguide-header .topbar-info a {
+    margin-left: 5px;
+    color: rgba(34,34,34,.75);
+    fill: rgba(34,34,34,.75);
+    border: none
+}
+
 #designguide .designguide-header .topbar-info a:after {
     content: none;
     display: inline;
+}
+
+#designguide .designguide-header .topbar-info a svg {
+    overflow: visible;
+    width: 2rem;
+    height: 2rem;
+    display: inline-block;
+    vertical-align: top;
+}
+
+#designguide .designguide-header .topbar-info a:hover {
+    color: rgba(0,0,0,.75);
+    fill: rgba(0,0,0,.75)
 }
 
 .iterator {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.7'
 
 services:
   jekyll:
-    image: swedbankpay/jekyll-plantuml:1.3.7
+    image: swedbankpay/jekyll-plantuml:1.3.8
     container_name: jekyll
     ports:
       - 4000:4000

--- a/package-lock.json
+++ b/package-lock.json
@@ -1075,37 +1075,6 @@
         "unist-util-visit": "^2.0.0"
       }
     },
-    "mdast-util-definitions": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/mdast-util-definitions/-/mdast-util-definitions-1.2.5.tgz",
-      "integrity": "sha512-CJXEdoLfiISCDc2JB6QLb79pYfI6+GcIH+W2ox9nMc7od0Pz+bovcHsiq29xAQY6ayqe/9CsK2VzkSJdg1pFYA==",
-      "requires": {
-        "unist-util-visit": "^1.0.0"
-      },
-      "dependencies": {
-        "unist-util-is": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-3.0.0.tgz",
-          "integrity": "sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A=="
-        },
-        "unist-util-visit": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
-          "integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
-          "requires": {
-            "unist-util-visit-parents": "^2.0.0"
-          }
-        },
-        "unist-util-visit-parents": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz",
-          "integrity": "sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==",
-          "requires": {
-            "unist-util-is": "^3.0.0"
-          }
-        }
-      }
-    },
     "mdast-util-heading-style": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/mdast-util-heading-style/-/mdast-util-heading-style-1.0.6.tgz",
@@ -1448,39 +1417,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/remark-heading-gap/-/remark-heading-gap-3.1.2.tgz",
       "integrity": "sha512-LNm1B4UveH1BkSLx4OPab0vW/p3KOc+8wV4kd94CHXmhuJ8i+kdroG2AonkUVzbOElc8U8ylxF3WPfmqYbRjJg=="
-    },
-    "remark-inline-links": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/remark-inline-links/-/remark-inline-links-3.1.3.tgz",
-      "integrity": "sha512-mgCdL6mDkhwT1i+XxPK/CcSJphwvvODmnsT0XFQdj5JazYl84BiGzYVbyI9ou7mDEu1y/dzTVKMM4luTDGJA/A==",
-      "requires": {
-        "mdast-util-definitions": "^1.1.1",
-        "unist-util-remove": "^1.0.0",
-        "unist-util-visit": "^1.1.0"
-      },
-      "dependencies": {
-        "unist-util-is": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-3.0.0.tgz",
-          "integrity": "sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A=="
-        },
-        "unist-util-visit": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
-          "integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
-          "requires": {
-            "unist-util-visit-parents": "^2.0.0"
-          }
-        },
-        "unist-util-visit-parents": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz",
-          "integrity": "sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==",
-          "requires": {
-            "unist-util-is": "^3.0.0"
-          }
-        }
-      }
     },
     "remark-lint": {
       "version": "6.0.6",
@@ -4701,21 +4637,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-3.1.0.tgz",
       "integrity": "sha512-w+PkwCbYSFw8vpgWD0v7zRCl1FpY3fjDSQ3/N/wNd9Ffa4gPi8+4keqt99N3XW6F99t/mUzp2xAhNmfKWp95QA=="
-    },
-    "unist-util-remove": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/unist-util-remove/-/unist-util-remove-1.0.3.tgz",
-      "integrity": "sha512-mB6nCHCQK0pQffUAcCVmKgIWzG/AXs/V8qpS8K72tMPtOSCMSjDeMc5yN+Ye8rB0FhcE+JvW++o1xRNc0R+++g==",
-      "requires": {
-        "unist-util-is": "^3.0.0"
-      },
-      "dependencies": {
-        "unist-util-is": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-3.0.0.tgz",
-          "integrity": "sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A=="
-        }
-      }
     },
     "unist-util-remove-position": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "remark-cli": "^8.0.0",
     "remark-frontmatter": "^1.3.3",
     "remark-heading-gap": "^3.0.0",
-    "remark-inline-links": "^3.0.4",
     "remark-lint": "^6.0.0",
     "remark-lint-blockquote-indentation": "^1.0.0",
     "remark-lint-checkbox-character-style": "^1.0.0",


### PR DESCRIPTION
- Adds back `topbar-info` styles removed in Design Guide 4.7.
- Upgrades to `jekyll-plantuml` version 1.3.8 to get rid of `livereload.js`.
- Also removes `livereload.js` because Jekyll seems to inject at the start of `<head>` without our help.
- Adds some includes to make the default layout more DRY and cleans it up a bit.