### PR TITLE
Remove gem jekyll-github-metadata

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,6 @@ source "https://rubygems.org"
 gemspec
 
 gem 'jekyll', '~> 4.1', group: :jekyll_plugins
-gem 'jekyll-github-metadata'
 gem 'jekyll-assets'
 gem 'jemoji'
 # Neccessary to prevent Jekyll errors. See https://github.com/github/personal-website/issues/166

--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,5 @@
 repository: SwedbankPay/swedbank-pay-design-guide-jekyll-theme
 plugins:
-  - "jekyll-github-metadata"
   - jemoji
   - jekyll-material-icon-tag
   - "kramdown-plantuml"


### PR DESCRIPTION
This fixes the erronious links genereated locally.