### PR TITLE
Add new card component

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -44,3 +44,5 @@ defaults:
       layout: default
 github:
   branch: master
+sass:
+  sass_dir: assets/css

--- a/_includes/card.html
+++ b/_includes/card.html
@@ -1,0 +1,36 @@
+{% assign title = include.title %}
+{% assign icon_content = include.icon_content %}
+{% assign icon_outlined = include.icon_outlined %}
+{% assign text = include.text %}
+{% assign horizontal = include.horizontal %}
+{% assign to = include.to %}
+{% if include.type %}
+{% assign type = include.type %}
+{% assign type_class = 'dx-card-' | append: type %}
+{% else %}
+{% assign type_class = '' %}
+{% endif %}
+
+{% if horizontal %}
+<a href="{{ to }}" class="dx-card dx-card-horizontal {{type_class}}">
+    <span class="dx-card-icon">
+        {{ icon_content }}
+    </span>
+    <span class="dx-card-content">
+        <span class="h4">{{ title }}</span>
+        <span>{{ text }}</span>
+    </span>
+    <i class="material-icons">arrow_forward</i>
+</a>
+{% else %}
+<a href="{{ to }}" class="dx-card {{type_class}}">
+    <span class="dx-card-icon">
+        <i class="material-icons{% if icon_outlined %}-outlined{% endif %}">{{ icon_content }}</i>
+    </span>
+    <span class="dx-card-content">
+        <span class="h4">{{ title }}</span>
+        <span>{{ text }}</span>
+    </span>
+    <i class="material-icons">arrow_forward</i>
+</a>
+{% endif %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -41,6 +41,7 @@
         <link rel="icon" type="image/png" sizes="16x16" href="{{ design_guide_url }}/icons/favicon-16x16.png">
         <link rel="icon" type="image/png" sizes="32x32" href="{{ design_guide_url }}/icons/favicon-32x32.png">
         <link rel="icon" type="image/png" sizes="228x228" href="{{ design_guide_url }}/icons/coast-228x228.png">
+        <link href="https://fonts.googleapis.com/css?family=Material+Icons+Outlined" rel="stylesheet">
         {%- include apple-mobile-headers.html design_guide_url=design_guide_url -%}
         <script src="{{ '/assets/js/mermaid.min.js' | relative_url }}"></script>
         {%- if site.search.enabled == true %}

--- a/assets/css/card.scss
+++ b/assets/css/card.scss
@@ -1,0 +1,116 @@
+.dx-card {
+    display: flex;
+    position: relative;
+    padding: 2.25rem 1.5rem 1.5rem;
+    margin: 2.5rem 0 1rem;
+    flex-direction: column;
+    border-radius: 4px;
+    box-shadow: 1px 2px 10px rgba(0, 0, 0, 0.1);
+    color: $brown;
+    text-decoration: none;
+
+    &:hover,
+    &:focus {
+        box-shadow: 1px 2px 20px rgba(0, 0, 0, 0.15);
+        color: $brown;
+
+        &:after {
+            position: absolute;
+            bottom: 0;
+            left: 0;
+            content: "";
+            width: 100%;
+            border-bottom-left-radius: 4px;
+            border-bottom-right-radius: 4px;
+            border-bottom: 4px solid $yellow;
+        }
+    }
+
+    > i {
+        color: $brown;
+    }
+    
+
+    .dx-card-icon {
+        display: flex;
+        position: absolute;
+        top: -1.25rem;
+        left: 2rem;
+        width: 2.5rem;
+        height: 2.5rem;
+        border-radius: 4px;
+        align-items: center;
+        justify-content: center;
+        color: $brown;
+        background-color: $yellow;
+    }
+
+    .dx-card-content {
+        display: flex;
+        flex-direction: column;
+        margin-bottom: 1.25rem;
+
+        h4 {
+            margin-top: 0;
+        }
+    }
+
+    &.dx-card-horizontal {
+        flex-direction: row;
+        justify-content: space-between;
+        align-items: center;
+        padding-top: 1.5rem;
+
+        .dx-card-icon {
+            font-family: "Akkurat Mono", monospace;
+        }
+        
+        .dx-card-content {
+            margin-bottom: 0;
+            margin-top: 0.75rem;
+
+            h3 {
+                margin-top: 0;
+            }
+        }
+    }
+
+    &.dx-card-sdk {
+        &:hover,
+        &:focus {
+
+        &:after {
+            border-bottom: 4px solid $turquoise;
+        }
+    }
+
+        > i {
+            color: $turquoise;
+        }
+
+        .dx-card-icon {
+            color: $white;
+            background-color: $turquoise;
+        }
+    }
+
+    &.dx-card-plugin {
+        &:hover,
+        &:focus {
+
+            &:after {
+                border-bottom: 4px solid $brand-info;
+            }
+        }
+
+        > i {
+            color: $brand-info;
+        }
+
+        .dx-card-icon {
+            color: $white;
+            background-color: $brand-info;
+        }
+    }
+
+}

--- a/assets/css/colors.scss
+++ b/assets/css/colors.scss
@@ -1,10 +1,10 @@
-$yellow: #FDC129;
-$light-turquoise: #EBF8F2;
+$yellow: #fdc129;
+$light-turquoise: #ebf8f2;
 $apricot: #fbf2ea;
 $pink: #efb7b6;
-$brand-info: #4572C0;
+$brand-info: #4572c0;
 $brand-info-light: #e8eff9;
 $brand-success-light: #f2f7eb;
-$turquoise: #31A3AE;
-$brown: #512B2B;
-$white: #FFFFFF;
+$turquoise: #31a3ae;
+$brown: #512b2b;
+$white: #fff;

--- a/assets/css/colors.scss
+++ b/assets/css/colors.scss
@@ -1,0 +1,10 @@
+$yellow: #FDC129;
+$light-turquoise: #EBF8F2;
+$apricot: #fbf2ea;
+$pink: #efb7b6;
+$brand-info: #4572C0;
+$brand-info-light: #e8eff9;
+$brand-success-light: #f2f7eb;
+$turquoise: #31A3AE;
+$brown: #512B2B;
+$white: #FFFFFF;

--- a/assets/css/swedbank-pay-design-guide-theme.scss
+++ b/assets/css/swedbank-pay-design-guide-theme.scss
@@ -7,6 +7,9 @@ TODO: Implement a table element style that @extends .table and .table-striped
       so we don't have to decorate all Markdown tables.
 */
 
+@import 'colors';
+@import 'card';
+
 $bg: #f5f2f0;
 $darkened-bg: darken($bg, 10%);
 

--- a/index.md
+++ b/index.md
@@ -191,6 +191,33 @@ body='This is an **informational**   alert *with*   `<markdown/>`{:.language-htm
 header='`{ "warning": "alert" }`{:.language-js}'
 body='This is a **warning**   alert with `<markdown/>`{:.language-html}.' %}
 
+## Cards
+
+{% include card.html title='Default'
+    text='This is a default card'
+    icon_content='credit_card'
+    to='/#cards'
+%}
+{% include card.html title='SDK'
+    text='This is a .dx-card-sdk card'
+    icon_content='settings'
+    type='sdk'
+    to='/#cards'
+%}
+{% include card.html title='Plugin'
+    text='This is a .dx-card-plugin card. This also has outlined icon'
+    icon_content='build'
+    icon_outlined=true
+    type='plugin'
+    to='/#cards'
+%}
+{% include card.html title='Horizontal'
+    text='This is a dx-card-horizontal card. Icons used with this card are just numbers'
+    icon_content='01'
+    horizontal=true
+    to='/#cards'
+%}
+
 ## Jumbotron
 
 {% include jumbotron.html body='**PayEx Checkout**   is a complete reimagination


### PR DESCRIPTION
The card components are implemented according to design in these [sketches](https://www.figma.com/file/JpcwYKZ1EymBaOHWZLHX57/Developer-Portal).

Added support for material-icons-outlined

Added `colors.scss` to make colors easier to access, and started work on splitting styling into different files, to make it easier to work with. Work on moving existing component-specific styling from main `.scss`-file will be done after the new sidebar component is merged