### PR TITLE
Fixes to active, titles and hidden

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ Gemfile.lock
 node_modules
 vendor
 *.generated*
+coverage/

--- a/_includes/title-header.html
+++ b/_includes/title-header.html
@@ -1,0 +1,24 @@
+{% assign title_lead = title | split: '–' | first %}
+{% assign title_main = title | split: '–' | last %}
+{% assign description = page.description %}
+{% assign estimated_read = page.estimated_read %}
+<div class="title-header">
+    <div class="title-header-container
+            {% if page.card_overview %} max-width-card-overview
+            {% else %} max-width
+            {% endif %}">
+        {% if title_lead != title_main %}
+        <h4>{{ page.lead_title }}</h4>
+        {% endif %}
+        <h1>{{ title_main }}</h1>
+        {% if estimated_read %}
+        <div class="title-header-estimated-read">
+            <i class="material-icons">schedule</i>
+            {{ estimated_read }} min read
+        </div>
+        {% endif %}
+        {% if description %}
+        <p>{{ description | markdownify }}</p>
+        {% endif %}
+    </div>
+</div>

--- a/_includes/title-header.html
+++ b/_includes/title-header.html
@@ -1,24 +1,32 @@
-{% assign title_lead = title | split: '–' | first %}
-{% assign title_main = title | split: '–' | last %}
+{% assign lead_title = page.lead_title %}
+{% assign main_title = page.main_title | default: page.title %}
 {% assign description = page.description %}
 {% assign estimated_read = page.estimated_read %}
+{% capture max_width_class %}
+    {% if page.card_overview %}
+        max-width-card-overview
+    {% else %}
+        max-width
+    {% endif %}
+{% endcapture %}
+
 <div class="title-header">
-    <div class="title-header-container
-            {% if page.card_overview %} max-width-card-overview
-            {% else %} max-width
-            {% endif %}">
-        {% if title_lead != title_main %}
-        <h4>{{ page.lead_title }}</h4>
+    <div class="title-header-container {{ max_width_class | strip }}">
+        {% if lead_title != nil %}
+            <h4>{{ lead_title }}</h4>
         {% endif %}
-        <h1>{{ title_main }}</h1>
+
+        <h1>{{ main_title }}</h1>
+
         {% if estimated_read %}
-        <div class="title-header-estimated-read">
-            <i class="material-icons">schedule</i>
-            {{ estimated_read }} min read
-        </div>
+            <div class="title-header-estimated-read">
+                <i class="material-icons">schedule</i>
+                {{ estimated_read }} min read
+            </div>
         {% endif %}
+
         {% if description %}
-        <p>{{ description | markdownify }}</p>
+            <p>{{ description | markdownify }}</p>
         {% endif %}
     </div>
 </div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -80,30 +80,7 @@
 
                     <main class="doc-view col-xxl-10 col-lg-9">
                         {% if page.layout != 'front-page' %}
-                        {% assign title_lead = title | split: '–' | first %}
-                        {% assign title_main = title | split: '–' | last %}
-                        {% assign description = page.description %}
-                        {% assign estimated_read = page.estimated_read %}
-                        <div class="title-header">
-                            <div class="title-header-container
-                                    {% if page.card_overview %} max-width-card-overview
-                                    {% else %} max-width
-                                    {% endif %}">
-                                {% if title_lead != title_main %}
-                                <h4>{{ title_lead }}</h4>
-                                {% endif %}
-                                <h1>{{ title_main }}</h1>
-                                {% if estimated_read %}
-                                <div class="title-header-estimated-read">
-                                    <i class="material-icons">schedule</i>
-                                    {{ estimated_read }} min read
-                                </div>
-                                {% endif %}
-                                {% if description %}
-                                <p>{{ description | markdownify }}</p>
-                                {% endif %}
-                            </div>
-                        </div>
+                            {% include title-header.html %}
                         {% endif %}
                         <div class="doc-container{% if page.layout == 'front-page' %} no-padding
                             {% elsif page.card_overview %} normal-padding max-width-card-overview

--- a/checkout/index.md
+++ b/checkout/index.md
@@ -1,5 +1,6 @@
 ---
-title: Checkout – Introduction
+section: Checkout
+title: Introduction
 estimated_read: 10
 description: |
     Swedbank Pay Checkout is a complete reimagination
@@ -25,7 +26,7 @@ card_list:
 ---
 
 {% comment %}
-Examples on how site.pages can be filtered and used with 
+Examples on how site.pages can be filtered and used with
 card-list/card-horizontal-list. Can also be used with pre-defined lists, such as
 card_list in front matter above.
 {% endcomment %}
@@ -42,8 +43,8 @@ where_exp: 'page', 'page.name != "index.md"' | sort: 'menu_order' %}
 ## Additional features
 
 {% assign additional_card_list = site.pages |
-where_exp: 'page', 'page.url != "/checkout/" and page.core != true and page.dir contains "/checkout/"' 
-| where: 'additional', true | sort: 'menu_order' 
+where_exp: 'page', 'page.url != "/checkout/" and page.core != true and page.dir contains "/checkout/"'
+| where: 'additional', true | sort: 'menu_order'
 %}
 
 {% include card-list.html card_list=additional_card_list

--- a/lib/sidebar.rb
+++ b/lib/sidebar.rb
@@ -23,20 +23,17 @@ module SwedbankPay
         @sidebar_renderer.enrich_jekyll
       end
 
-      def post_write(site)
+      def post_write
         @sidebar_renderer.render
       end
     end
   end
 end
 
-# SwedbankPay::Sidebar.init
-
 Jekyll::Hooks.register :site, :pre_render do |site, _|
   SwedbankPay::Sidebar.pre_render site
 end
 
-
-Jekyll::Hooks.register :site, :post_write do |site|
-  SwedbankPay::Sidebar.post_write site
+Jekyll::Hooks.register :site, :post_write do |_|
+  SwedbankPay::Sidebar.post_write
 end

--- a/lib/sidebar_html_builder.rb
+++ b/lib/sidebar_html_builder.rb
@@ -103,7 +103,7 @@ module SwedbankPay
 
     def headers_markup(page, current_path)
       # If there's no page headers, only return a leaf item for the page itself.
-      return leaf_markup(page.path, page.title.item, page.level) unless page.headers?
+      return leaf_markup(page.path, page.title.main, page.level) unless page.headers?
 
       # If there's no children, only return the headers as leaf node items.
       return page.headers.map { |h| header_markup(page, h) }.join('') if page.children.empty?
@@ -127,14 +127,14 @@ module SwedbankPay
     end
 
     def section_title(page)
-      return page.title.section unless page.title.section.nil?
+      return page.title.lead unless page.title.lead.nil?
       return page.parent.title.to_s unless page.parent.nil? || page.parent.title.nil?
 
       ''
     end
 
     def item_title(page)
-      page.title.item
+      page.title.main
     end
   end
 end

--- a/lib/sidebar_html_builder.rb
+++ b/lib/sidebar_html_builder.rb
@@ -28,7 +28,7 @@ module SwedbankPay
         next if page.ignore?
 
         sub_items_markup = sub_items_markup(page, current_path)
-        markup << item_markup(page, current_path, page.level, sub_items_markup)
+        markup << item_markup(page, current_path, sub_items_markup, false)
       end
 
       markup
@@ -48,9 +48,12 @@ module SwedbankPay
       ''
     end
 
-    def item_markup(page, current_path, level, sub_items_markup)
+    def item_markup(page, current_path, sub_items_markup, is_leaf)
+      # If we're rendering a leaf node, just set the level to a non-zero value
+      # to get the 'nav-subgroup' class and such.
+      level = is_leaf ? -1 : page.level
       title_markup = title_markup(page, level)
-      item_class = item_class(page, current_path, level)
+      item_class = item_class(page, current_path, level, is_leaf)
       group_heading_class = group_heading_class(level)
 
       "<li class=\"#{item_class}\">
@@ -62,8 +65,8 @@ module SwedbankPay
       </li>"
     end
 
-    def item_class(page, current_path, level)
-      active = active?(page, current_path, level)
+    def item_class(page, current_path, level, is_leaf)
+      active = page.active?(current_path, is_leaf: is_leaf)
       item_class = group_class(level)
       item_class += ' active' if active
       item_class
@@ -108,7 +111,7 @@ module SwedbankPay
       headers_markup = page.headers.map { |h| header_markup(page, h) }.join('')
       headers_markup = "<ul class=\"nav-ul\">#{headers_markup}</ul>"
 
-      item_markup(page, current_path, page.level + 1, headers_markup)
+      item_markup(page, current_path, headers_markup, true)
     end
 
     def header_markup(page, header)
@@ -121,10 +124,6 @@ module SwedbankPay
     def leaf_markup(href, title, level = 0)
       leaf_class = level.positive? ? 'nav-leaf nav-subgroup-leaf' : 'nav-leaf'
       "<li class=\"#{leaf_class}\"><a href=\"#{href}\">#{title}</a></li>"
-    end
-
-    def active?(page, current_path, level)
-      level.zero? ? page.active?(current_path) : page.path == current_path
     end
 
     def section_title(page)

--- a/lib/sidebar_html_builder.rb
+++ b/lib/sidebar_html_builder.rb
@@ -21,39 +21,28 @@ module SwedbankPay
     def build_markup(pages, current_page)
       return '' if pages.empty?
 
-      current_path = current_path(current_page)
       markup = ''
 
       pages.each do |page|
-        next if page.ignore?
+        if page.hidden_for?(current_page)
+          name = current_page.respond_to?(:name) ? current_page.name : current_page.to_s
+          Jekyll.logger.debug("           Sidebar: #{page.name} is hidden for #{name}")
+          next
+        end
 
-        sub_items_markup = sub_items_markup(page, current_path)
-        markup << item_markup(page, current_path, sub_items_markup, false)
+        sub_items_markup = sub_items_markup(page, current_page)
+        markup << item_markup(page, current_page, sub_items_markup, false)
       end
 
       markup
     end
 
-    def current_path(current_page)
-      if current_page.nil?
-        Jekyll.logger.warn('           Sidebar: Nil current_page')
-        return ''
-      end
-
-      return current_page if current_page.is_a? String
-      return current_page.path if current_page.respond_to?(:path)
-
-      Jekyll.logger.warn("           Sidebar: #{current_page.class} ('#{current_page}') does not respond to :path.")
-
-      ''
-    end
-
-    def item_markup(page, current_path, sub_items_markup, is_leaf)
+    def item_markup(page, current_page, sub_items_markup, is_leaf)
       # If we're rendering a leaf node, just set the level to a non-zero value
       # to get the 'nav-subgroup' class and such.
       level = is_leaf ? -1 : page.level
       title_markup = title_markup(page, level)
-      item_class = item_class(page, current_path, level, is_leaf)
+      item_class = item_class(page, current_page, level, is_leaf)
       group_heading_class = group_heading_class(level)
 
       "<li class=\"#{item_class}\">
@@ -65,8 +54,8 @@ module SwedbankPay
       </li>"
     end
 
-    def item_class(page, current_path, level, is_leaf)
-      active = page.active?(current_path, is_leaf: is_leaf)
+    def item_class(page, current_page, level, is_leaf)
+      active = page.active?(current_page, is_leaf: is_leaf)
       item_class = group_class(level)
       item_class += ' active' if active
       item_class
@@ -82,16 +71,16 @@ module SwedbankPay
     end
 
     def title_markup(page, level)
-      section_title = section_title(page)
-      return "<span>#{section_title}</span>" if level.zero?
+      lead_title = lead_title(page)
+      return "<span>#{lead_title}</span>" if level.zero?
 
-      item_title = item_title(page)
-      "<a href=\"#{page.path}\">#{item_title}</a>"
+      main_title = main_title(page)
+      "<a href=\"#{page.path}\">#{main_title}</a>"
     end
 
-    def sub_items_markup(page, current_path)
-      headers_markup = headers_markup(page, current_path)
-      child_markup = build_markup(page.children, current_path)
+    def sub_items_markup(page, current_page)
+      headers_markup = headers_markup(page, current_page)
+      child_markup = build_markup(page.children, current_page)
 
       return '' if headers_markup.empty? && child_markup.empty?
 
@@ -101,9 +90,10 @@ module SwedbankPay
       </ul>"
     end
 
-    def headers_markup(page, current_path)
+    def headers_markup(page, current_page)
       # If there's no page headers, only return a leaf item for the page itself.
-      return leaf_markup(page.path, page.title.main, page.level) unless page.headers?
+      main_title = page.title.nil? ? nil : page.title.main
+      return leaf_markup(page.path, main_title, page.level) unless page.headers?
 
       # If there's no children, only return the headers as leaf node items.
       return page.headers.map { |h| header_markup(page, h) }.join('') if page.children.empty?
@@ -111,7 +101,7 @@ module SwedbankPay
       headers_markup = page.headers.map { |h| header_markup(page, h) }.join('')
       headers_markup = "<ul class=\"nav-ul\">#{headers_markup}</ul>"
 
-      item_markup(page, current_path, headers_markup, true)
+      item_markup(page, current_page, headers_markup, true)
     end
 
     def header_markup(page, header)
@@ -126,15 +116,21 @@ module SwedbankPay
       "<li class=\"#{leaf_class}\"><a href=\"#{href}\">#{title}</a></li>"
     end
 
-    def section_title(page)
-      return page.title.lead unless page.title.lead.nil?
+    def lead_title(page)
+      return page.title.lead unless page.title.nil? || page.title.lead.nil?
       return page.parent.title.to_s unless page.parent.nil? || page.parent.title.nil?
 
       ''
     end
 
-    def item_title(page)
-      page.title.main
+    def main_title(page)
+      unless page.nil? || page.title.nil?
+        main = page.title.main
+
+        return main || page.title.to_s
+      end
+
+      ''
     end
   end
 end

--- a/lib/sidebar_page.rb
+++ b/lib/sidebar_page.rb
@@ -54,22 +54,22 @@ module SwedbankPay
     end
 
     def hidden_for?(other_page)
-        # The current page should be hidden for the other page unless the
-        # other page is also hidden.
-        #
-        # TODO: Make it so that hiddden pages within a section are visible
-        #       for each other, but not for other sections, regardless if
-        #       they are hidden or not.
-        hidden = hidden?
+      # The current page should be hidden for the other page unless the
+      # other page is also hidden.
+      #
+      # TODO: Make it so that hiddden pages within a section are visible
+      #       for each other, but not for other sections, regardless if
+      #       they are hidden or not.
+      hidden = hidden?
 
-        if other_page.nil? || !other_page.is_a?(SidebarPage)
-          Jekyll.logger.debug("           Sidebar: Other page '#{other_page}' is nil or not a SidebarPage")
-          return hidden
-        end
+      if other_page.nil? || !other_page.is_a?(SidebarPage)
+        Jekyll.logger.debug("           Sidebar: Other page '#{other_page}' is nil or not a SidebarPage")
+        return hidden
+      end
 
-        return false if other_page.hidden?
+      return false if other_page.hidden?
 
-        hidden
+      hidden
     end
 
     def children=(children)

--- a/lib/sidebar_page.rb
+++ b/lib/sidebar_page.rb
@@ -28,11 +28,18 @@ module SwedbankPay
       @children = SidebarPageCollection.new(self)
     end
 
-    def active?(current_path)
+    def active?(current_path, is_leaf: false)
+      raise ArgumentError, 'current_path cannot be nil' if current_path.nil?
+      raise ArgumentError, 'current_path must be a String' unless current_path.is_a? String
+
       return true if @path == current_path
 
-      @children.each do |child|
-        return true if child.active?(current_path)
+      # If we're on a leaf node item, such as when rendering the first header
+      # item of a sub-group, its children's active state must be disregarded.
+      unless is_leaf
+        @children.each do |child|
+          return true if child.active?(current_path, is_leaf: is_leaf)
+        end
       end
 
       false

--- a/lib/sidebar_page_title.rb
+++ b/lib/sidebar_page_title.rb
@@ -1,15 +1,31 @@
 # frozen_string_literal: true
 
+require 'jekyll'
+require_relative 'sidebar_page'
+
 module SwedbankPay
   # Represents the title of a SidebarPage
   class SidebarPageTitle
-    attr_reader :section, :item
+    attr_reader :main, :section
 
-    def initialize(title)
-      @title = title
-      parts = title.split('–')
-      @section = parts.first.strip
-      @item = parts.last.strip
+    def self.parse(jekyll_page, sidebar_page)
+      raise ArgumentError, 'jekyll_page cannot be nil' if jekyll_page.nil?
+      raise ArgumentError, 'jekyll_page must be a Jekyll::Page' unless jekyll_page.is_a? Jekyll::Page
+      raise ArgumentError, 'sidebar_page cannot be nil' if sidebar_page.nil?
+      raise ArgumentError, 'sidebar_page must be a SidebarPage' unless sidebar_page.is_a? SidebarPage
+
+      title = jekyll_page['title']
+      section = jekyll_page['section']
+      return nil if title.nil?
+
+      SidebarPageTitle.new(title, section, sidebar_page)
+    end
+
+    def lead
+      section = find_section(@page)
+      return section unless section.nil?
+
+      @lead
     end
 
     def to_s
@@ -24,6 +40,32 @@ module SwedbankPay
       return -1 if other.nil?
 
       @title <=> other.to_s
+    end
+
+    private
+
+    def initialize(title, section, page)
+      raise ArgumentError, 'title cannot be nil' if title.nil?
+      raise ArgumentError, 'title must be a String' unless title.is_a? String
+      raise ArgumentError, 'page cannot be nil' if page.nil?
+      raise ArgumentError, 'page must be a SidebarPage' unless page.is_a? SidebarPage
+
+      @page = page
+      @title = title
+      parts = title.split('–')
+      @section = section
+      @lead = parts.first.strip
+      @main = parts.last.strip
+    end
+
+    def find_section(page)
+      # Return the 'section' front matter if it can be found on the current page.
+      return page.title.section unless page.nil? || page.title.nil? || page.title.section.nil? || page.title.section.empty?
+
+      # Recurse upwards to the root (until there is no parent).
+      return find_section(page.parent) unless page.nil? || page.parent.nil?
+
+      nil
     end
   end
 end

--- a/lib/sidebar_parser.rb
+++ b/lib/sidebar_parser.rb
@@ -17,7 +17,10 @@ module SwedbankPay
         path = SidebarPath.new(filename).to_s
         page = pages[path]
 
-        raise ArgumentError, "No page found for '#{path}'." if page.nil?
+        if page.nil?
+          Jekyll.logger.warn("           Sidebar: No page found for <#{path}>.")
+          next
+        end
 
         page.doc = doc
         page.filename = filename

--- a/lib/sidebar_parser.rb
+++ b/lib/sidebar_parser.rb
@@ -1,15 +1,21 @@
 # frozen_string_literal: true
 
+require 'jekyll'
 require_relative 'sidebar_path'
 
 module SwedbankPay
   # The Sidebar renderer
   class SidebarParser
     def initialize(site)
+      raise ArgumentError, 'Site cannot be nil' if site.nil?
+      raise ArgumentError, 'Site must be a Jekyll::Site' unless site.is_a? Jekyll::Site
+
       @site = site
     end
 
-    def parse(pages)
+    def parse
+      pages = build_pages_hash
+
       destination = @site.config['destination']
 
       Dir.glob("#{destination}/**/*.html") do |filename|
@@ -32,6 +38,17 @@ module SwedbankPay
     end
 
     private
+
+    def build_pages_hash
+      pages_hash = {}
+
+      @site.pages.each do |jekyll_page|
+        sidebar_page = SidebarPage.new(jekyll_page)
+        pages_hash[sidebar_page.path] = sidebar_page
+      end
+
+      pages_hash
+    end
 
     def find_headers(doc)
       headers = []

--- a/lib/sidebar_parser.rb
+++ b/lib/sidebar_parser.rb
@@ -24,7 +24,7 @@ module SwedbankPay
         page = pages[path]
 
         if page.nil?
-          Jekyll.logger.warn("           Sidebar: No page found for <#{path}>.")
+          Jekyll.logger.debug("           Sidebar: No page found for <#{path}>.")
           next
         end
 

--- a/lib/sidebar_renderer.rb
+++ b/lib/sidebar_renderer.rb
@@ -40,7 +40,8 @@ module SwedbankPay
 
         File.open('_site/sidebar.html', 'w') { |f| f.write(sidebar_html) }
       rescue StandardError => e
-        Jekyll.logger.error("           Sidebar: Unable to render sidebar for '#{page.filename}'.")
+        name = page.filename || page.name
+        Jekyll.logger.error("           Sidebar: Unable to render sidebar for '#{name}'.")
         Jekyll.logger.debug("           Sidebar: #{e.message}. #{e.backtrace.inspect}")
         return nil
       end

--- a/lib/sidebar_renderer.rb
+++ b/lib/sidebar_renderer.rb
@@ -5,14 +5,32 @@ require_relative 'sidebar_html_builder'
 module SwedbankPay
   # Renders the Sidebar
   class SidebarRenderer
-    def render(tree)
+    def initialize(tree)
+      raise ArgumentError, 'pages cannot be nil' if tree.nil?
       raise ArgumentError, 'pages must be an SidebarTreeBuilder' unless tree.is_a? SidebarTreeBuilder
 
       @tree = tree
-      render_pages(tree)
+    end
+
+    def enrich_jekyll
+      enrich_jekyll_pages(@tree)
+    end
+
+    def render
+      render_pages(@tree)
     end
 
     private
+
+    def enrich_jekyll_pages(pages)
+      return if pages.empty?
+
+      pages.each do |page|
+        page.enrich_jekyll
+
+        enrich_jekyll_pages(page.children)
+      end
+    end
 
     def render_pages(pages)
       return if pages.empty?

--- a/lib/sidebar_text_builder.rb
+++ b/lib/sidebar_text_builder.rb
@@ -13,7 +13,7 @@ module SwedbankPay
 
     def to_s
       name = @page.name == '/' ? '/' : "/#{@page.name}"
-      title = @page.title.nil? ? '?' : @page.title.item
+      title = @page.title.nil? ? '?' : @page.title.main
       s = "#{indent} #{name}: #{title} (#{@page.coordinate})\n"
 
       unless @page.children.empty?

--- a/lib/sidebar_text_builder.rb
+++ b/lib/sidebar_text_builder.rb
@@ -34,7 +34,7 @@ module SwedbankPay
 
       increment = @page.level > 1 ? @page.level + 1 : @page.level
 
-      "┝╾#{('─' * increment)}"
+      "┝╾#{'─' * increment}"
     end
 
     def todo

--- a/payments/secrets/index.md
+++ b/payments/secrets/index.md
@@ -1,5 +1,6 @@
 ---
 title: Secret payments
+hide_from_sidebar: true
 ---
 
 ## How we do secret payments

--- a/payments/secrets/super-secret.md
+++ b/payments/secrets/super-secret.md
@@ -1,5 +1,6 @@
 ---
 title: Secrets in payments
+hide_from_sidebar: true
 ---
 
 ## Don't render this

--- a/spec/sidebar_after_payment_spec.rb
+++ b/spec/sidebar_after_payment_spec.rb
@@ -14,11 +14,11 @@ describe SwedbankPay::Sidebar do
     }
 
     it 'has active item' do
-      is_expected.to have_tag('ul', class: 'nav-ul') do
+      is_expected.to have_tag('ul.main-nav-ul') do
         with_tag('li.nav-group.active') do
-          with_tag('ul', class: 'nav-ul') do
+          with_tag('ul.nav-ul') do
             with_tag('li.nav-subgroup.active') do
-              with_tag('div', class: 'nav-subgroup-heading') do
+              with_tag('div.nav-subgroup-heading') do
                 with_tag('i.material-icons', text: 'arrow_right')
                 with_tag('a[href="/checkout/after-payment"]', text: 'After Payment')
               end

--- a/spec/sidebar_index_file_spec.rb
+++ b/spec/sidebar_index_file_spec.rb
@@ -68,5 +68,11 @@ describe SwedbankPay::Sidebar do
         end
       end
     end
+
+    # Hidden pages shouldn't be visible for non-hidden pages
+    it 'has no navigation for hidden pages' do
+      is_expected.not_to have_tag('a[href="/payments/secrets/"]')
+      is_expected.not_to have_tag('a[href="/payments/secrets/super-secret"]')
+    end
   end
 end

--- a/spec/sidebar_index_file_spec.rb
+++ b/spec/sidebar_index_file_spec.rb
@@ -14,16 +14,16 @@ describe SwedbankPay::Sidebar do
     }
 
     it 'has nav leaf' do
-      is_expected.to have_tag('ul', class: 'nav-ul') do
-        with_tag('li', class: 'nav-leaf') do
+      is_expected.to have_tag('ul.nav-ul') do
+        with_tag('li.nav-leaf') do
           with_tag('a[href="/checkout/capture#step-5-capture-the-funds"]', text: 'Step 5: Capture the funds')
         end
       end
     end
 
     it 'has subgroup' do
-      is_expected.to have_tag('li', class: 'nav-subgroup') do
-        with_tag('div', class: 'nav-subgroup-heading') do
+      is_expected.to have_tag('li.nav-subgroup') do
+        with_tag('div.nav-subgroup-heading') do
           with_tag('i.material-icons', text: 'arrow_right')
           with_tag('a[href="/checkout/payment-menu"]', text: 'Payment Menu')
         end
@@ -31,9 +31,9 @@ describe SwedbankPay::Sidebar do
     end
 
     it 'has active home item' do
-      is_expected.to have_tag('ul#dx-sidebar-main-nav-ul', class: 'main-nav-ul') do
-        with_tag('li', class: 'nav-group active') do
-          with_tag('div', class: 'nav-group-heading') do
+      is_expected.to have_tag('ul#dx-sidebar-main-nav-ul.main-nav-ul') do
+        with_tag('li.nav-group.active') do
+          with_tag('div.nav-group-heading') do
             with_tag('i.material-icons', text: 'arrow_right')
             with_tag('span', text: 'Home')
           end
@@ -42,16 +42,16 @@ describe SwedbankPay::Sidebar do
     end
 
     it 'has checkin items' do
-      is_expected.to have_tag('li', class: 'nav-subgroup') do
-        with_tag('div', class: 'nav-subgroup-heading') do
+      is_expected.to have_tag('li.nav-subgroup') do
+        with_tag('div.nav-subgroup-heading') do
           with_tag('i.material-icons', text: 'arrow_right')
           with_tag('a[href="/checkout/checkin"]', text: 'Checkin')
         end
-        with_tag('ul', class: 'nav-ul') do
-          with_tag('li', class: 'nav-leaf') do
+        with_tag('ul.nav-ul') do
+          with_tag('li.nav-leaf') do
             with_tag('a[href="/checkout/checkin#step-1-initiate-session-for-consumer-identification"]', text: 'Step 1: Initiate session for consumer identification')
           end
-          with_tag('li', class: 'nav-leaf') do
+          with_tag('li.nav-leaf') do
             with_tag('a[href="/checkout/checkin#step-2-display-swedbank-pay-checkin-module"]', text: 'Step 2: Display Swedbank Pay Checkin module')
           end
         end
@@ -59,9 +59,9 @@ describe SwedbankPay::Sidebar do
     end
 
     it 'has introduction item' do
-      is_expected.to have_tag('ul', class: 'nav-ul') do
-        with_tag('li', class: 'nav-subgroup') do
-          with_tag('div', class: 'nav-subgroup-heading') do
+      is_expected.to have_tag('ul.nav-ul') do
+        with_tag('li.nav-subgroup') do
+          with_tag('div.nav-subgroup-heading') do
             with_tag('i.material-icons', text: 'arrow_right')
             with_tag('a[href="/checkout/"]', text: 'Introduction')
           end

--- a/spec/sidebar_po_file_spec.rb
+++ b/spec/sidebar_po_file_spec.rb
@@ -15,15 +15,18 @@ describe SwedbankPay::Sidebar do
 
     it 'has expected nav structure' do
       is_expected.to have_tag('ul', class: 'nav-ul') do
-        with_tag('li', class: 'nav-subgroup') do
-          with_tag('div', class: 'nav-subgroup-heading') do
-            with_tag('i.material-icons', text: 'arrow_right')
-            with_tag('a[href="/checkout/checkin"]', text: 'Checkin')
-          end
+        with_tag('li.nav-subgroup.active') do
           with_tag('ul', class: 'nav-ul') do
-            with_tag('li', class: 'nav-leaf') do
-              with_tag('a[href="/checkout/checkin#step-1-initiate-session-for-consumer-identification"]',
-                       text: 'Step 1: Initiate session for consumer identification')
+            with_tag('li.nav-subgroup.active') do
+              with_tag('div', class: 'nav-subgroup-heading') do
+                with_tag('i.material-icons', text: 'arrow_right')
+                with_tag('a[href="/checkout/features/payment-orders"]', text: 'Payment Orders')
+              end
+              with_tag('ul', class: 'nav-ul') do
+                with_tag('li', class: 'nav-leaf') do
+                  with_tag('a[href="/checkout/features/payment-orders#payment-orders"]', text: 'Payment Orders')
+                end
+              end
             end
           end
         end

--- a/spec/sidebar_po_file_spec.rb
+++ b/spec/sidebar_po_file_spec.rb
@@ -32,5 +32,14 @@ describe SwedbankPay::Sidebar do
         end
       end
     end
+
+    it 'has expected titles' do
+      is_expected.to have_tag('div', class: 'title-header') do
+        with_tag('div', class: 'title-header-container') do
+          with_tag('h4', text: 'Checkout')
+          with_tag('h1', text: 'Payment Orders')
+        end
+      end
+    end
   end
 end

--- a/spec/sidebar_po_file_spec.rb
+++ b/spec/sidebar_po_file_spec.rb
@@ -14,16 +14,16 @@ describe SwedbankPay::Sidebar do
     }
 
     it 'has expected nav structure' do
-      is_expected.to have_tag('ul', class: 'nav-ul') do
+      is_expected.to have_tag('ul.nav-ul') do
         with_tag('li.nav-subgroup.active') do
-          with_tag('ul', class: 'nav-ul') do
+          with_tag('ul.nav-ul') do
             with_tag('li.nav-subgroup.active') do
-              with_tag('div', class: 'nav-subgroup-heading') do
+              with_tag('div.nav-subgroup-heading') do
                 with_tag('i.material-icons', text: 'arrow_right')
                 with_tag('a[href="/checkout/features/payment-orders"]', text: 'Payment Orders')
               end
-              with_tag('ul', class: 'nav-ul') do
-                with_tag('li', class: 'nav-leaf') do
+              with_tag('ul.nav-ul') do
+                with_tag('li.nav-leaf') do
                   with_tag('a[href="/checkout/features/payment-orders#payment-orders"]', text: 'Payment Orders')
                 end
               end
@@ -34,8 +34,8 @@ describe SwedbankPay::Sidebar do
     end
 
     it 'has expected titles' do
-      is_expected.to have_tag('div', class: 'title-header') do
-        with_tag('div', class: 'title-header-container') do
+      is_expected.to have_tag('div.title-header') do
+        with_tag('div.title-header-container') do
           with_tag('h4', text: 'Checkout')
           with_tag('h1', text: 'Payment Orders')
         end

--- a/spec/sidebar_resource_file_spec.rb
+++ b/spec/sidebar_resource_file_spec.rb
@@ -14,17 +14,17 @@ describe SwedbankPay::Sidebar do
     }
 
     it 'has expected nav structure' do
-      is_expected.to have_tag('ul', class: 'nav-ul') do
-        with_tag('li', class: 'nav-leaf nav-subgroup-leaf') do
+      is_expected.to have_tag('ul.nav-ul') do
+        with_tag('li.nav-leaf') do
           with_tag('a[href="/resources/"]', text: 'Resources')
         end
-        with_tag('li', class: 'nav-subgroup-leaf') do
-          with_tag('div', class: 'nav-subgroup-heading') do
+        with_tag('li.nav-subgroup') do
+          with_tag('div.nav-subgroup-heading') do
             with_tag('i.material-icons', text: 'arrow_right')
             with_tag('a[href="/resources/release-notes"]', text: 'Release Notes')
           end
         end
-        with_tag('li', class: 'nav-leaf nav-subgroup-leaf') do
+        with_tag('li.nav-leaf.nav-subgroup-leaf') do
           with_tag('a[href="/resources/sub-resources/"]', text: 'Sub-resources')
         end
       end

--- a/spec/sidebar_spec.rb
+++ b/spec/sidebar_spec.rb
@@ -21,6 +21,7 @@ describe sidebar do
 
       its(:path) { is_expected.to eq '/' }
       its(:children) { is_expected.to be_an_instance_of SwedbankPay::SidebarPageCollection }
+      its(:hidden?) { is_expected.to be false }
 
       describe 'title' do
         it { expect(subject.title.to_s).to eq 'Home' }
@@ -39,6 +40,7 @@ describe sidebar do
       its(:active?, '/checkout/after-payment') { is_expected.to be true }
       its(:active?, '/checkout/features/payment-orders') { is_expected.to be true }
       its(:active?, '/checkout/features/payment-orders', is_leaf: true) { is_expected.to be false }
+      its(:hidden?) { is_expected.to be false }
 
       describe 'children[3]' do
         subject { sidebar.pages[3].children[3] }
@@ -64,6 +66,46 @@ describe sidebar do
     end
 
     describe '[5]' do
+      subject { sidebar.pages[5] }
+
+      describe 'title' do
+        it { expect(subject.title.to_s).to eq 'Payments' }
+      end
+
+      describe 'children' do
+        subject { sidebar.pages[5].children }
+
+        its(:length) { is_expected.to eq 3 }
+
+        describe '[2]' do
+          subject { sidebar.pages[5].children[2] }
+
+          its(:hidden?) { is_expected.to be true }
+
+          describe 'title' do
+            it { expect(subject.title.to_s).to eq 'Secret payments' }
+          end
+
+          describe 'children' do
+            subject { sidebar.pages[5].children[2].children }
+
+            its(:length) { is_expected.to eq 1 }
+
+            describe '[0]' do
+              subject { sidebar.pages[5].children[2].children[0] }
+
+              its(:hidden?) { is_expected.to be true }
+
+              describe 'title' do
+                it { expect(subject.title.to_s).to eq 'Secrets in payments' }
+              end
+            end
+          end
+        end
+      end
+    end
+
+    describe '[6]' do
       subject { sidebar.pages[6] }
 
       describe 'title' do

--- a/spec/sidebar_spec.rb
+++ b/spec/sidebar_spec.rb
@@ -23,35 +23,26 @@ describe sidebar do
       its(:children) { is_expected.to be_an_instance_of SwedbankPay::SidebarPageCollection }
 
       describe 'title' do
-        subject { sidebar.pages[0].title.to_s }
-        it { is_expected.to eq 'Home' }
+        it { expect(subject.title.to_s).to eq 'Home' }
       end
     end
 
-    describe '[1]' do
-      describe 'title' do
-        subject { sidebar.pages[1].title.to_s }
-        it { is_expected.to eq 'Page 1' }
-      end
+    describe '[1].title' do
+      it { expect(sidebar.pages[1].title.to_s).to eq 'Page 1' }
     end
 
     describe '[3]' do
       subject { sidebar.pages[3] }
 
       its(:path) { is_expected.to eq '/checkout/' }
-
-      describe '#active?' do
-        it { expect(subject.active?('/checkout/after-payment')).to be true }
-      end
+      its(:active?, '/checkout/') { is_expected.to be true }
+      its(:active?, '/checkout/after-payment') { is_expected.to be true }
 
       describe 'children[3]' do
         subject { sidebar.pages[3].children[3] }
 
         its(:path) { is_expected.to eq '/checkout/after-payment' }
-
-        describe '#active?' do
-          it { expect(subject.active?('/checkout/after-payment')).to be true }
-        end
+        its(:active?, '/checkout/after-payment') { is_expected.to be true }
       end
     end
 
@@ -59,8 +50,7 @@ describe sidebar do
       subject { sidebar.pages[6] }
 
       describe 'title' do
-        subject { sidebar.pages[6].title.to_s }
-        it { is_expected.to eq 'Resources' }
+        it { expect(subject.title.to_s).to eq 'Resources' }
       end
 
       describe 'children' do
@@ -68,27 +58,16 @@ describe sidebar do
 
         its(:length) { is_expected.to eq 6 }
 
-        describe '[0]' do
-          subject { sidebar.pages[6].children[0] }
-
-          describe 'title' do
-            subject { sidebar.pages[6].children[0].title.to_s }
-            it { is_expected.to eq 'Alpha' }
-          end
+        describe '[0].title' do
+          it { expect(subject[0].title.to_s).to eq 'Alpha' }
         end
 
-        describe '[1]' do
-          describe 'title' do
-            subject { sidebar.pages[6].children[1].title.to_s }
-            it { is_expected.to eq 'Beta' }
-          end
+        describe '[1].title' do
+          it { expect(subject[1].title.to_s).to eq 'Beta' }
         end
 
-        describe '[1]' do
-          describe 'title' do
-            subject { sidebar.pages[6].children[2].title.to_s }
-            it { is_expected.to eq 'Gamma' }
-          end
+        describe '[2].title' do
+          it { expect(subject[2].title.to_s).to eq 'Gamma' }
         end
       end
     end

--- a/spec/sidebar_spec.rb
+++ b/spec/sidebar_spec.rb
@@ -37,12 +37,29 @@ describe sidebar do
       its(:path) { is_expected.to eq '/checkout/' }
       its(:active?, '/checkout/') { is_expected.to be true }
       its(:active?, '/checkout/after-payment') { is_expected.to be true }
+      its(:active?, '/checkout/features/payment-orders') { is_expected.to be true }
+      its(:active?, '/checkout/features/payment-orders', is_leaf: true) { is_expected.to be false }
 
       describe 'children[3]' do
         subject { sidebar.pages[3].children[3] }
 
         its(:path) { is_expected.to eq '/checkout/after-payment' }
         its(:active?, '/checkout/after-payment') { is_expected.to be true }
+      end
+
+      describe 'children[4]' do
+        subject { sidebar.pages[3].children[4] }
+
+        its(:path) { is_expected.to eq '/checkout/features/' }
+        its(:active?, '/checkout/features/payment-orders') { is_expected.to be true }
+        its(:active?, '/checkout/features/payment-orders', is_leaf: true) { is_expected.to be false }
+
+        describe 'children[0]' do
+          subject { sidebar.pages[3].children[4].children[0] }
+
+          its(:path) { is_expected.to eq '/checkout/features/payment-orders' }
+          its(:active?, '/checkout/features/payment-orders') { is_expected.to be true }
+        end
       end
     end
 

--- a/spec/sidebar_super_secret_file_spec.rb
+++ b/spec/sidebar_super_secret_file_spec.rb
@@ -14,41 +14,40 @@ describe SwedbankPay::Sidebar do
       expect(File).to exist(super_secret_path)
     }
 
-    # <li class="nav-subgroup active">
-    #   <div class="nav-subgroup-heading">
-    #     <i class="material-icons">arrow_right</i>
-    #     <a href="/payments/secrets/">Secret payments</a>
-    #   </div>
-    #   <ul class="nav-ul">
-    #     <li class="nav-subgroup">
-    #       <div class="nav-subgroup-heading">
-    #         <i class="material-icons">arrow_right</i>
-    #         <a href="/payments/secrets/">Secret payments</a>
-    #       </div>
-    #       <ul class="nav-ul">
-    #         <li class="nav-leaf"><a href="/payments/secrets/#how-we-do-secret-payments">How we do secret payments</a></li>
-    #       </ul>
-    #     </li>
-    #     <li class="nav-subgroup active">
-    #       <div class="nav-subgroup-heading">
-    #         <i class="material-icons">arrow_right</i>
-    #         <a href="/payments/secrets/super-secret">Secrets in payments</a>
-    #       </div>
-    #       <ul class="nav-ul">
-    #         <li class="nav-leaf"><a href="/payments/secrets/super-secret#dont-render-this">Don’t render this</a></li>
-    #       </ul>
-    #     </li>
-    #   </ul>
-    # </li>
-
     # The navigation for a section that has `hide_from_sidebar: true` should not
     # be hidden from itself.
     it 'has expected nav structure' do
-      is_expected.to have_tag('ul', class: 'nav-ul') do
-        with_tag('li', class: 'nav-subgroup active') do
-          with_tag('div', class: 'nav-subgroup-heading') do
+      is_expected.to have_tag('ul.nav-ul') do
+        with_tag('li.nav-subgroup.active') do
+          with_tag('div.nav-subgroup-heading') do
             with_tag('i.material-icons', text: 'arrow_right')
             with_tag('a[href="/payments/secrets/"]', text: 'Secret payments')
+          end
+
+          with_tag('ul.nav-ul') do
+            with_tag('li.nav-subgroup') do
+              with_tag('div.nav-subgroup-heading') do
+                with_tag('i.material-icons', text: 'arrow_right')
+                with_tag('a[href="/payments/secrets/"]', text: 'Secret payments')
+              end
+              with_tag('ul.nav-ul') do
+                with_tag('li.nav-leaf') do
+                  with_tag('a[href="/payments/secrets/#how-we-do-secret-payments"]', text: 'How we do secret payments')
+                end
+              end
+            end
+
+            with_tag('li.nav-subgroup.active') do
+              with_tag('div.nav-subgroup-heading') do
+                with_tag('i.material-icons', text: 'arrow_right')
+                with_tag('a[href="/payments/secrets/super-secret"]', text: 'Secrets in payments')
+              end
+              with_tag('ul.nav-ul') do
+                with_tag('li.nav-leaf') do
+                  with_tag('a[href="/payments/secrets/super-secret#dont-render-this"]', text: 'Don’t render this')
+                end
+              end
+            end
           end
         end
       end

--- a/spec/sidebar_super_secret_file_spec.rb
+++ b/spec/sidebar_super_secret_file_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'sidebar'
+
+describe SwedbankPay::Sidebar do
+  include_context 'shared'
+  # TODO: Hidden pages should be hidden from non-hidden pages, but not from other hidden pages within the same or lower hierarchy.
+  super_secret_path = File.join(@dest_dir, 'payments', 'secrets' , 'super-secret.html')
+
+  describe super_secret_path do
+    subject { File.read(super_secret_path) }
+
+    it {
+      expect(File).to exist(super_secret_path)
+    }
+
+    # <li class="nav-subgroup active">
+    #   <div class="nav-subgroup-heading">
+    #     <i class="material-icons">arrow_right</i>
+    #     <a href="/payments/secrets/">Secret payments</a>
+    #   </div>
+    #   <ul class="nav-ul">
+    #     <li class="nav-subgroup">
+    #       <div class="nav-subgroup-heading">
+    #         <i class="material-icons">arrow_right</i>
+    #         <a href="/payments/secrets/">Secret payments</a>
+    #       </div>
+    #       <ul class="nav-ul">
+    #         <li class="nav-leaf"><a href="/payments/secrets/#how-we-do-secret-payments">How we do secret payments</a></li>
+    #       </ul>
+    #     </li>
+    #     <li class="nav-subgroup active">
+    #       <div class="nav-subgroup-heading">
+    #         <i class="material-icons">arrow_right</i>
+    #         <a href="/payments/secrets/super-secret">Secrets in payments</a>
+    #       </div>
+    #       <ul class="nav-ul">
+    #         <li class="nav-leaf"><a href="/payments/secrets/super-secret#dont-render-this">Don’t render this</a></li>
+    #       </ul>
+    #     </li>
+    #   </ul>
+    # </li>
+
+    # The navigation for a section that has `hide_from_sidebar: true` should not
+    # be hidden from itself.
+    it 'has expected nav structure' do
+      is_expected.to have_tag('ul', class: 'nav-ul') do
+        with_tag('li', class: 'nav-subgroup active') do
+          with_tag('div', class: 'nav-subgroup-heading') do
+            with_tag('i.material-icons', text: 'arrow_right')
+            with_tag('a[href="/payments/secrets/"]', text: 'Secret payments')
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR fixes the following:

1. `SidebarPage#active?` now works for pages more than 2 levels deep.
2. `title-header.html` is added as a new include to display the new `section` front matter as lead title.
3. The sidebar of hidden pages are now visible to themselves as well as for all other hidden pages, but are hidden for visible pages. This is the simplest implementation; adding support for sub-section filtering such that any hidden section is only visible to pages within the same section is not tackled and I don't think it is going to be necessary either.