### PR TITLE
DX-1288: Always hide search from the sidebar, even from itself

### DIFF
--- a/lib/sidebar_page.rb
+++ b/lib/sidebar_page.rb
@@ -56,6 +56,11 @@ module SwedbankPay
     end
 
     def hidden_for?(other_page)
+      if @jekyll_page.data['layout'] == 'search'
+        # Never show the search result page in the menu.
+        return true
+      end
+
       # The current page should be hidden for the other page unless the
       # other page is also hidden.
       hidden = hidden?

--- a/search.md
+++ b/search.md
@@ -1,5 +1,4 @@
 ---
 title: Search
 layout: search
-hide_from_sidebar: true
 ---

--- a/spec/sidebar_search_file_spec.rb
+++ b/spec/sidebar_search_file_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'sidebar'
+
+describe SwedbankPay::Sidebar do
+  include_context 'shared'
+  search_path = File.join(@dest_dir, 'search.html')
+
+  describe search_path do
+    subject { File.read(search_path) }
+
+    it {
+      expect(File).to exist(search_path)
+    }
+
+    it 'does not have search item' do
+      is_expected.not_to have_tag('.main-nav-ul span', text: 'Search')
+      is_expected.not_to have_tag('.main-nav-ul a[href="/search"]')
+    end
+  end
+end


### PR DESCRIPTION
Always hide search from the sidebar, even from itself.