### PR TITLE
DX-1508: Autogenerate card lists on child pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ node_modules
 vendor
 *.generated*
 coverage/
+*.log

--- a/_includes/card-list.html
+++ b/_includes/card-list.html
@@ -7,10 +7,14 @@ type: sdk | module - Empty type result in default card styling
 col_class(required): Describes what grid column class(es) each card should be wrapped in
 {%- endcomment -%}
 
+{% assign cards = include.card_list | default: page.children %}
+{% assign col_class = include.col_class | default: 'col-lg-4' %}
+
 <div class="row card-list">
-    {% for card in include.card_list %}
+    {% for card in cards %}
         {% assign title = card.title | split: '–' | last %}
-        {% assign link_to = card.extensionless_path | default: card.url %}
+        {% assign link_to = card.absolute_path | default: card.url %}
+
         {% assign card_type = card.card.type | default: card.card_type | default: include.type %}
         {% assign icon_content = card.card.icon.content | default: card.icon.content %}
         {% assign icon_outlined = card.card.icon.outlined | default: card.icon.outlined %}
@@ -19,7 +23,7 @@ col_class(required): Describes what grid column class(es) each card should be wr
         {% assign horizontal = card.card.horizontal | default: false %}
         {% assign disabled = card.card.disabled | default: card.disabled %}
 
-        <div class="{{ include.col_class }}">
+        <div class="{{ col_class }}">
             {% include card.html
                 title=title
                 text=card.description

--- a/checkout/v2/features/core/3d-secure-2.md
+++ b/checkout/v2/features/core/3d-secure-2.md
@@ -1,8 +1,11 @@
 ---
 title: 3-D Secure 2
 estimated_read: 5
-description: Authenticating the cardholder.
+description: Authenticating the cardholder
 menu_order: 1200
+card:
+  icon:
+    content: 3d_rotation
 ---
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam volutpat, nisl

--- a/checkout/v2/features/core/cancel.md
+++ b/checkout/v2/features/core/cancel.md
@@ -1,9 +1,12 @@
 ---
 title: Cancel
 estimated_read: 3
-description: |
-  Cancelling the authorization and releasing the funds.
+description: Cancelling the authorization and releasing the funds
 menu_order: 1400
+card:
+  icon:
+    content: pan_tool
+    outlined: true
 ---
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam volutpat, nisl

--- a/checkout/v2/features/core/index.md
+++ b/checkout/v2/features/core/index.md
@@ -53,7 +53,6 @@ card_list:
 ---
 
 {:.heading-line}
-
 ## Core Features
 
 {% include card-list.html card_list=page.card_list

--- a/checkout/v2/features/core/index.md
+++ b/checkout/v2/features/core/index.md
@@ -8,52 +8,9 @@ icon:
   content: remove_red_eye
 additional: true
 menu_order: 1100
-card_list:
-- title: 3-D Secure 2
-  description: Authenticating the cardholder
-  url:  /checkout/v2/features/core/3d-secure-2
-  icon:
-    content: 3d_rotation
-- title: Abort
-  description: Aborting a created payment
-  url: /checkout/v2/features/core/payment-order-abort
-  icon:
-    content: pan_tool
-    outlined: true
-- title: Cancel
-  description: Cancelling the authorization and releasing the funds
-  url: /checkout/v2/features/core/cancel
-  icon:
-    content: pan_tool
-    outlined: true
-- title: Capture
-  description: Capturing the authorized funds
-  url: /checkout/v2/features/core/payment-order-capture
-  icon:
-    content: compare_arrows
-    outlined: true
-- title: Payment Order
-  description: Creating the payment order
-  url:  /checkout/v2/features/core/payment-order
-  icon:
-    content: credit_card
-    outlined: true
-- title: Reversal
-  description: How to reverse a payment
-  url: /checkout/v2/features/core/reversal
-  icon:
-    content: keyboard_return
-    outlined: true
-- title: Settlement & Reconciliation
-  description: Balancing the books
-  url:  /checkout/v2/features/core/settlement-reconciliation
-  icon:
-    content: description
-    outlined: true
 ---
 
 {:.heading-line}
-## Core Features
+## {{ page.title }}
 
-{% include card-list.html card_list=page.card_list
-    col_class="col-lg-4" %}
+{% include card-list.html %}

--- a/checkout/v2/features/core/payment-order-abort.md
+++ b/checkout/v2/features/core/payment-order-abort.md
@@ -1,9 +1,12 @@
 ---
 title: Abort
 estimated_read: 3
-description: |
-  Aborting a created payment.
+description: Aborting a created payment
 menu_order: 1300
+card:
+  icon:
+    content: pan_tool
+    outlined: true
 ---
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam volutpat, nisl

--- a/checkout/v2/features/core/payment-order-capture.md
+++ b/checkout/v2/features/core/payment-order-capture.md
@@ -1,9 +1,12 @@
 ---
 title: Capture
 estimated_read: 5
-description: |
-  Capturing the authorized funds.
+description: Capturing the authorized funds
 menu_order: 1500
+card:
+  icon:
+    content: compare_arrows
+    outlined: true
 ---
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam volutpat, nisl

--- a/checkout/v2/features/core/payment-order.md
+++ b/checkout/v2/features/core/payment-order.md
@@ -1,9 +1,12 @@
 ---
 title: Payment Order
 estimated_read: 5
-description: |
-  Creating the payment order
+description: Creating the payment order
 menu_order: 1600
+card:
+  icon:
+    content: credit_card
+    outlined: true
 ---
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam volutpat, nisl

--- a/checkout/v2/features/core/reversal.md
+++ b/checkout/v2/features/core/reversal.md
@@ -1,9 +1,12 @@
 ---
 title: Reversal
 estimated_read: 4
-description: |
-  How to reverse a payment.
+description: How to reverse a payment
 menu_order: 1700
+card:
+  icon:
+    content: keyboard_return
+    outlined: true
 ---
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam volutpat, nisl

--- a/checkout/v2/features/core/settlement-reconciliation.md
+++ b/checkout/v2/features/core/settlement-reconciliation.md
@@ -1,9 +1,12 @@
 ---
 title: Settlement & Reconciliation
 estimated_read: 16
-description: |
-  Balancing the books.
+description: Balancing the books
 menu_order: 1800
+card:
+  icon:
+    content: description
+    outlined: true
 ---
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam volutpat, nisl

--- a/lib/sidebar_page.rb
+++ b/lib/sidebar_page.rb
@@ -115,6 +115,7 @@ module SwedbankPay
       @jekyll_page.data['lead_title'] = @title.lead
       @jekyll_page.data['main_title'] = @title.main
       @jekyll_page.data['children'] = @children
+      @jekyll_page.data['absolute_path'] = @path
     end
 
     def save

--- a/spec/card_checkout_core_features_spec.rb
+++ b/spec/card_checkout_core_features_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+describe 'Checkout Core Features' do
+  include_context 'shared'
+  core_features_path = File.join(@dest_dir, 'checkout', 'v2', 'features', 'core', 'index.html')
+
+  describe core_features_path do
+    subject { File.read(core_features_path) }
+
+    it {
+      expect(File).to exist(core_features_path)
+    }
+
+    it 'has expected cards' do
+      is_expected.to have_tag('article') do
+        with_tag('h2#core-features', :with => { :class => 'heading-line' }) do
+          with_tag('a.header-anchor', :with => { :href => '#core-features' })
+        end
+        with_tag('.row.card-list') do
+          with_tag('.col-lg-4') do
+            with_tag('a.dx-card', :with => { :href => '/checkout/v2/features/core/3d-secure-2' }) do
+              with_tag('.dx-card-icon') do
+                with_tag('i.material-icons', :text => /3d_rotation/)
+              end
+              with_tag('.dx-card-content') do
+                with_tag('.h4', :text => '3-D Secure 2')
+                with_tag('span', :text => 'Authenticating the cardholder')
+              end
+              with_tag('i.material-icons', :text => /arrow_forward/)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/card_checkout_core_features_spec.rb
+++ b/spec/card_checkout_core_features_spec.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: true
+# frozen_string_literal: false
 
 describe 'Checkout Core Features' do
   include_context 'shared'
@@ -17,19 +17,33 @@ describe 'Checkout Core Features' do
           with_tag('a.header-anchor', :with => { :href => '#core-features' })
         end
         with_tag('.row.card-list') do
-          with_tag('.col-lg-4') do
-            with_tag('a.dx-card', :with => { :href => '/checkout/v2/features/core/3d-secure-2' }) do
-              with_tag('.dx-card-icon') do
-                with_tag('i.material-icons', :text => /3d_rotation/)
-              end
-              with_tag('.dx-card-content') do
-                with_tag('.h4', :text => '3-D Secure 2')
-                with_tag('span', :text => 'Authenticating the cardholder')
-              end
-              with_tag('i.material-icons', :text => /arrow_forward/)
-            end
-          end
+          with_card('3d-secure-2', '3-D Secure 2', 'Authenticating the cardholder', '3d_rotation', false)
+          with_card('payment-order-abort', 'Abort', 'Aborting a created payment', 'pan_tool')
+          with_card('cancel', 'Cancel', 'Cancelling the authorization and releasing the funds', 'pan_tool')
+          with_card('payment-order-capture', 'Capture', 'Capturing the authorized funds', 'compare_arrow')
+          with_card('payment-order', 'Payment Order', 'Creating the payment order', 'credit_card')
+          with_card('reversal', 'Reversal', 'How to reverse a payment', 'keyboard_return')
+          with_card('settlement-reconciliation', 'Settlement & Reconciliation', 'Balancing the books', 'description')
         end
+      end
+    end
+  end
+
+  def with_card(href, title, body, icon, icon_outlined = true)
+    href = "/checkout/v2/features/core/#{href}"
+    icon_type = 'material-icons'
+    icon_type << '-outlined' if icon_outlined
+
+    with_tag('.col-lg-4') do
+      with_tag('a.dx-card', :with => { :href => href }) do
+        with_tag('.dx-card-icon') do
+          with_tag('i', :text => /#{icon}/, :with => { :class => icon_type })
+        end
+        with_tag('.dx-card-content') do
+          with_tag('.h4', :text => title)
+          with_tag('span', :text => body)
+        end
+        with_tag('i.material-icons', :text => /arrow_forward/)
       end
     end
   end

--- a/spec/card_overview_spec.rb
+++ b/spec/card_overview_spec.rb
@@ -18,7 +18,7 @@ describe 'Card Overview' do
         end
         with_tag('.row.card-list') do
           with_tag('.col-lg-6') do
-            with_tag('a.dx-card.dx-card-module', :with => { :href => '/cards/deck1/card1.html' }) do
+            with_tag('a.dx-card.dx-card-module', :with => { :href => '/cards/deck1/card1' }) do
               with_tag('.dx-card-icon') do
                 with_tag('i.material-icons-outlined', :text => /attach_money/)
               end
@@ -34,7 +34,7 @@ describe 'Card Overview' do
     end
 
     it 'has card with no icon' do
-      is_expected.to have_tag('a.dx-card', :with => { :href => '/cards/deck1/card2.html' }) do
+      is_expected.to have_tag('a.dx-card', :with => { :href => '/cards/deck1/card2' }) do
         with_tag('.dx-card-icon.d-none') do
           with_tag('i.material-icons', :text => /^\s*$/)
         end
@@ -54,7 +54,7 @@ describe 'Card Overview' do
 
         with_tag('.row.card-list') do
           with_tag('.col-lg-12') do
-            with_tag('a.dx-card', :with => { :href => '/cards/deck2/card1.html' }) do
+            with_tag('a.dx-card', :with => { :href => '/cards/deck2/card1' }) do
               with_tag('.dx-card-icon') do
                 with_tag('i.material-icons', :text => /api/)
               end
@@ -71,7 +71,7 @@ describe 'Card Overview' do
 
     it 'has card with svg icon' do
       is_expected.to have_tag('.col-lg-12') do
-        with_tag('a.dx-card', :with => { :href => '/cards/deck2/card2.html' }) do
+        with_tag('a.dx-card', :with => { :href => '/cards/deck2/card2' }) do
           with_tag('.dx-card-icon') do
             with_tag('svg')
           end
@@ -86,7 +86,7 @@ describe 'Card Overview' do
 
     it 'has horizontal card' do
       is_expected.to have_tag('.dx-card-horizontal') do
-        with_tag('a.dx-card', :with => { :href => '/cards/deck2/card3.html' }) do
+        with_tag('a.dx-card', :with => { :href => '/cards/deck2/card3' }) do
           with_tag('.dx-card-content') do
             with_tag('.h4', :text => 'Deck 2 Card 3')
             with_tag('span', :text => 'Deck Two Card Three')

--- a/spec/card_overview_spec.rb
+++ b/spec/card_overview_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-describe "Card Overview" do
-  include_context "shared"
-  card_index = File.join(@dest_dir, "cards", "index.html")
+describe 'Card Overview' do
+  include_context 'shared'
+  card_index = File.join(@dest_dir, 'cards', 'index.html')
 
   describe card_index do
     subject { File.read(card_index) }


### PR DESCRIPTION
Add support for autogenerated card lists on child pages, removing the need for duplicate front matter.