### PR TITLE
DX-1654 Switch to queue action

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,3 +1,9 @@
+queue_rules:
+  - name: default
+    conditions:
+      # Conditions to get out of the queue (= merged)
+      - check-success=build
+
 pull_request_rules:
   - name: Automatic approve on dependabot PR
     conditions:
@@ -10,9 +16,9 @@ pull_request_rules:
     conditions:
       - author~=^dependabot(|-preview)\[bot\]$
     actions:
-      merge:
+      queue:
         method: merge
-        strict: smart
+        name: default
 
   - name: Thank contributor
     conditions:


### PR DESCRIPTION
Switching to `queue` action due to `strict mode` deprecation ref https://blog.mergify.com/strict-mode-deprecation/