### PR TITLE
DX-1660: Remove kramdown-plantuml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,7 +4,6 @@ plugins:
   - jekyll-material-icon-tag
   - jekyll-redirect-from
   - jemoji
-  - kramdown-plantuml
   - swedbank-pay-design-guide-jekyll-theme
 # To include node_modules and other folders that are excluded by default:
 exclude:

--- a/swedbank-pay-design-guide-jekyll-theme.gemspec
+++ b/swedbank-pay-design-guide-jekyll-theme.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'jekyll-material-icon-tag', '~> 1', '>= 1.1'
   spec.add_runtime_dependency 'jekyll-redirect-from', '~> 0.16'
   spec.add_runtime_dependency 'jemoji', '~> 0.12'
-  spec.add_runtime_dependency 'kramdown-plantuml', '~> 1', '>= 1.2'
   spec.add_runtime_dependency 'nokogiri', '~> 1.11'
   spec.add_runtime_dependency 'rake', '~> 13.0'
   spec.add_runtime_dependency 'sass', '~> 3', '>= 3.7'


### PR DESCRIPTION
`kramdown-plantuml` performs writes after sidebar, which seems to remove sidebar entirely from the output HTML. This remove kramdown-plantuml to debug why the sidebar click events are not working properly. Once the sidebar events are fixed we probably need to implement https://github.com/SwedbankPay/kramdown-plantuml/issues/86 in order to fix the problem of `kramdown-plantuml` overwriting the sidebar.