### PR TITLE
Remove `verify` from Mergify's success criteria

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -12,7 +12,6 @@ pull_request_rules:
       - '#commits-behind=0' # Only merge up to date pull requests
       - check-success=build
       - check-success=license/cla
-      - check-success=verify
       - check-success=spec
     actions:
       merge:


### PR DESCRIPTION
Remove `verify` from Mergify's success criteria, since the `verify` build step was removed in b080e8cba0439b3ccab15448028f6b05f2ae5b43.