### PR TITLE
Add support for root-level fields

### DIFF
--- a/_sass/swedbank-pay-design-guide-theme.scss
+++ b/_sass/swedbank-pay-design-guide-theme.scss
@@ -330,8 +330,13 @@ body {
             }
 
             code {
-                border: 2px solid $yellow;
+                border: 1px solid $yellow;
+                border-radius: 8px;
             }
+        }
+
+        .field-level-0::before {
+            content: '';
         }
 
         .field-level-2 {

--- a/checkout/v2/checkin.md
+++ b/checkout/v2/checkin.md
@@ -75,6 +75,7 @@ When the request has been sent, a response containing an array of operations tha
 {:.table .table-striped}
 | Field                     | Type     | Description                                                                                                                                       |
 | :------------------------ | :------- | :------------------------------------------------------------------------------------------------------------------------------------------------ |
+| {% f root, 0 %}           | `solid`  | A root, for brewing beer used to kill ghost pirates.                                                                                              |
 | {% f token %}             | `string` | A session token used to initiate Checkout UI.                                                                                                     |
 | {% f operations %}        | `array`  | The array of operation objects to choose from, described in detail in the table below.                                                            |
 | {% f rel, 2 %}            | `string` | The relational name of the operation, used as a programmatic identifier to find the correct operation given the current state of the application. |

--- a/lib/field_tag.rb
+++ b/lib/field_tag.rb
@@ -38,9 +38,14 @@ module SwedbankPay
     def level(values)
       return 1 if values.size == 1
 
-      field_level = values[1].strip.to_i
+      field_level = values[1].strip
 
-      field_level.positive? ? field_level : 1
+      # Check if the level is a valid number, otherwise default to 1
+      return 1 unless /\A[-+]?\d*\.?\d+\z/.match(field_level)
+
+      field_level = field_level.to_i
+
+      field_level >= 0 ? field_level : 1
     rescue StandardError
       1
     end

--- a/spec/field_tag_spec.rb
+++ b/spec/field_tag_spec.rb
@@ -37,6 +37,26 @@ describe SwedbankPay::FieldTag do
     end
   end
 
+  context 'with zero level' do
+    let(:input) { 'operations, 0' }
+
+    its(:raw) { is_expected.to eq('f operations, 0') }
+
+    its(:render, Liquid::Context.new) do
+      is_expected.to eq('<span class="field-level field-level-0"><code class="language-json highlighter-rouge">operations</code></span>')
+    end
+  end
+
+  context 'with negative level' do
+    let(:input) { 'operations, -1' }
+
+    its(:raw) { is_expected.to eq('f operations, -1') }
+
+    its(:render, Liquid::Context.new) do
+      is_expected.to eq('<span class="field-level field-level-1"><code class="language-json highlighter-rouge">operations</code></span>')
+    end
+  end
+
   context 'with nil field name' do
     let(:input) { nil }
 


### PR DESCRIPTION
Add support for root-level fields in the `f` Liquid tag so all fields are styled equally in field tables.

<img width="1297" alt="field table" src="https://user-images.githubusercontent.com/12283/221691734-d45b3814-c260-41e2-8377-133af50fcee9.png">
